### PR TITLE
0.17.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.17.2] - 02-Mar-2020
+
+**Milestone**: Fushicho.4(RC3 0.9.3.1)
+ Versions  |   |
+---|---|---
+SDK Core| v0.17.2 | https://www.npmjs.com/package/symbol-sdk
+Catbuffer | v0.0.11 | https://www.npmjs.com/package/catbuffer-typescript
+Client Library | v0.8.5  | https://www.npmjs.com/package/symbol-openapi-typescript-node-client
+
+- **[BREAKING CHANGE]** Added `s-part` of transaction signature to transaction hash.
+- Added `numStatements` to `blockInfo` model.
+- Fixed `mosaicNonce` issue in `createTransactionFromPayload`.
+- Improved error handling in WS `listener` and `TransactionService`.
+- Improved test coverage.
+
 ## [0.17.1] - 24-Feb-2020
 
 **Milestone**: Fushicho.4(RC3 0.9.3.1)
@@ -392,6 +407,7 @@ Client Library | v0.7.20-alpha.6  | https://www.npmjs.com/package/nem2-sdk-opena
 
 - Initial code release.
 
+[0.17.1]: https://github.com/nemtech/symbol-sdk-typescript-javascript/compare/v0.17.1...v0.17.2
 [0.17.1]: https://github.com/nemtech/symbol-sdk-typescript-javascript/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/nemtech/symbol-sdk-typescript-javascript/compare/v0.16.5...v0.17.0
 [0.16.5]: https://github.com/nemtech/symbol-sdk-typescript-javascript/compare/v0.16.4...v0.16.5

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ The Symbol SDK for TypeScript / JavaScript allows you to develop web, mobile, an
 
 **!!! Please be noted that the NEM2-SDK is rebranded to SYMBOL-SDK now**.
 
-Due to a network upgrade with [catapult-server@Fushicho](https://github.com/nemtech/catapult-server/releases/tag/v0.9.3.1) version, **it is recommended to use this package's 0.17.1 version and upwards to use this package with Fushicho versioned networks**.
+Due to a network upgrade with [catapult-server@Fushicho](https://github.com/nemtech/catapult-server/releases/tag/v0.9.3.1) version, **it is recommended to use this package's 0.17.2 version and upwards to use this package with Fushicho versioned networks**.
 
-The upgrade to this package's [version v0.17.0](https://github.com/nemtech/symbol-sdk-typescript-javascript/releases/tag/v0.17.1) is mandatory for **fushicho compatibility**.
+The upgrade to this package's [version v0.17.2](https://github.com/nemtech/symbol-sdk-typescript-javascript/releases/tag/v0.17.2) is mandatory for **fushicho compatibility**.
 
 You can find the complete changelog [here](CHANGELOG.md).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "symbol-sdk",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symbol-sdk",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Reactive symbol sdk for typescript and javascript",
   "scripts": {
     "pretest": "npm run build",


### PR DESCRIPTION
**Milestone**: Fushicho.4(RC3 0.9.3.1)
 Versions  |   |
---|---|---
SDK Core| v0.17.2 | https://www.npmjs.com/package/symbol-sdk
Catbuffer | v0.0.11 | https://www.npmjs.com/package/catbuffer-typescript
Client Library | v0.8.5  | https://www.npmjs.com/package/symbol-openapi-typescript-node-client

- **[BREAKING CHANGE]** Added `s-part` of transaction signature to transaction hash.
- Added `numStatements` to `blockInfo` model.
- Fixed `mosaicNonce` issue in `createTransactionFromPayload`.
- Improved error handling in WS `listener` and `TransactionService`.
- Improved test coverage.
