### PR TITLE
v0.17.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 ## [0.17.4] - 07-Apr-2020
 
 **Milestone**: Fushicho.4(RC3 0.9.3.2)
- Versions  |   |
+ Package  | Version  | Link
 ---|---|---
 SDK Core| v0.17.4 | https://www.npmjs.com/package/symbol-sdk
 Catbuffer | v0.0.11 | https://www.npmjs.com/package/catbuffer-typescript
@@ -24,7 +24,7 @@ Client Library | v0.8.9  | https://www.npmjs.com/package/symbol-openapi-typescri
 ## [0.17.3] - 04-Mar-2020
 
 **Milestone**: Fushicho.4(RC3 0.9.3.1)
- Versions  |   |
+ Package  | Version  | Link
 ---|---|---
 SDK Core| v0.17.3 | https://www.npmjs.com/package/symbol-sdk
 Catbuffer | v0.0.11 | https://www.npmjs.com/package/catbuffer-typescript
@@ -36,7 +36,7 @@ Client Library | v0.8.5  | https://www.npmjs.com/package/symbol-openapi-typescri
 ## [0.17.2] - 02-Mar-2020
 
 **Milestone**: Fushicho.4(RC3 0.9.3.1)
- Versions  |   |
+ Package  | Version  | Link
 ---|---|---
 SDK Core| v0.17.2 | https://www.npmjs.com/package/symbol-sdk
 Catbuffer | v0.0.11 | https://www.npmjs.com/package/catbuffer-typescript
@@ -51,7 +51,7 @@ Client Library | v0.8.5  | https://www.npmjs.com/package/symbol-openapi-typescri
 ## [0.17.1] - 24-Feb-2020
 
 **Milestone**: Fushicho.4(RC3 0.9.3.1)
- Versions  |   |
+ Package  | Version  | Link
 ---|---|---
 SDK Core| v0.17.1 | https://www.npmjs.com/package/symbol-sdk
 Catbuffer | v0.0.11 | https://www.npmjs.com/package/catbuffer-typescript
@@ -65,7 +65,7 @@ Client Library | v0.8.5  | https://www.npmjs.com/package/symbol-openapi-typescri
 ## [0.17.0] - 17-Feb-2020
 
 **Milestone**: Fushicho.4(RC3 0.9.3.1)
- Versions  |   |
+ Package  | Version  | Link
 ---|---|---
 SDK Core | v0.17.0 | https://www.npmjs.com/package/nem2-sdk
 catbuffer | v0.0.11 | https://www.npmjs.com/package/catbuffer
@@ -85,7 +85,7 @@ Client Library | v0.8.4  | https://www.npmjs.com/package/nem2-sdk-openapi-typesc
 ## [0.16.5] - 30-Jan-2020
 
 **Milestone**: Fushicho.4(RC3)
- Versions  |   |
+ Package  | Version  | Link
 ---|---|---
 SDK Core| v0.16.5 | https://www.npmjs.com/package/nem2-sdk
 catbuffer Library| v0.0.11 | https://www.npmjs.com/package/catbuffer
@@ -96,7 +96,7 @@ Client Library | v0.7.20-beta.7  | https://www.npmjs.com/package/nem2-sdk-openap
 ## [0.16.4] - 30-Jan-2020
 
 **Milestone**: Fushicho.4(RC3)
- Versions  |   |
+ Package  | Version  | Link
 ---|---|---
 SDK Core| v0.16.4 | https://www.npmjs.com/package/nem2-sdk
 catbuffer Library| v0.0.11 | https://www.npmjs.com/package/catbuffer
@@ -114,7 +114,7 @@ Client Library | v0.7.20-beta.7  | https://www.npmjs.com/package/nem2-sdk-openap
 ## [0.16.3] - 09-Jan-2020
 
 **Milestone**: Fushicho.3
- Versions  |   |
+ Package  | Version  | Link
 ---|---|---
 SDK Core| v0.16.3 | https://www.npmjs.com/package/nem2-sdk
 catbuffer Library| v0.0.7 | https://www.npmjs.com/package/catbuffer
@@ -125,7 +125,7 @@ Client Library | v0.7.20-beta.6  | https://www.npmjs.com/package/nem2-sdk-openap
 ## [0.16.2] - 06-Jan-2020
 
 **Milestone**: Fushicho.3
- Versions  |   |
+ Package  | Version  | Link
 ---|---|---
 SDK Core| v0.16.2 | https://www.npmjs.com/package/nem2-sdk
 catbuffer Library| v0.0.7 | https://www.npmjs.com/package/catbuffer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.17.4] - 07-Apr-2020
+
+**Milestone**: Fushicho.4(RC3 0.9.3.2)
+ Versions  |   |
+---|---|---
+SDK Core| v0.17.4 | https://www.npmjs.com/package/symbol-sdk
+Catbuffer | v0.0.11 | https://www.npmjs.com/package/catbuffer-typescript
+Client Library | v0.8.9  | https://www.npmjs.com/package/symbol-openapi-typescript-node-client
+
+- Added `SimpleWallet.toDTO()` method which returns JSON serialized object.
+- Applied latest Symbol OpenAPI generated code (`v0.8.9`).
+- Added automated release scripts for Travis.
+- Added multiple version spport for TS-Doc.
+- Optimised unit tests and improved test coverage.
+- Changed internal method `getSigningByte` to public.
+- Removed constant of namespace `MaxDepth (default: 3)` which can be retrieved from network properties endpoint.
+- Fixed Github security alert on `minimist` package.
+
 ## [0.17.3] - 04-Mar-2020
 
 **Milestone**: Fushicho.4(RC3 0.9.3.1)
@@ -419,6 +437,7 @@ Client Library | v0.7.20-alpha.6  | https://www.npmjs.com/package/nem2-sdk-opena
 
 - Initial code release.
 
+[0.17.4]: https://github.com/nemtech/symbol-sdk-typescript-javascript/compare/v0.17.3...v0.17.4
 [0.17.3]: https://github.com/nemtech/symbol-sdk-typescript-javascript/compare/v0.17.2...v0.17.3
 [0.17.2]: https://github.com/nemtech/symbol-sdk-typescript-javascript/compare/v0.17.1...v0.17.2
 [0.17.1]: https://github.com/nemtech/symbol-sdk-typescript-javascript/compare/v0.17.0...v0.17.1

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ The Symbol SDK for TypeScript / JavaScript allows you to develop web, mobile, an
 
 ## Important Notes
 
-### _Fushicho_ Network Compatibility (catapult-server@0.9.3.1)
+### _Fushicho_ Network Compatibility (catapult-server@0.9.3.2)
 
 **!!! Please be noted that the NEM2-SDK is rebranded to SYMBOL-SDK now**.
 
-Due to a network upgrade with [catapult-server@Fushicho](https://github.com/nemtech/catapult-server/releases/tag/v0.9.3.1) version, **it is recommended to use this package's 0.17.3 version and upwards to use this package with Fushicho versioned networks**.
+Due to a network upgrade with [catapult-server@Fushicho](https://github.com/nemtech/catapult-server/releases/tag/v0.9.3.2) version, **it is recommended to use this package's 0.17.4 version and upwards to use this package with Fushicho versioned networks**.
 
-The upgrade to this package's [version v0.17.3](https://github.com/nemtech/symbol-sdk-typescript-javascript/releases/tag/v0.17.3) is mandatory for **fushicho compatibility**.
+The upgrade to this package's [version v0.17.4](https://github.com/nemtech/symbol-sdk-typescript-javascript/releases/tag/v0.17.4) is mandatory for **fushicho compatibility**.
 
 Find the complete release notes [here](CHANGELOG.md).
 


### PR DESCRIPTION
## [0.17.4] - 07-Apr-2020

**Milestone**: Fushicho.4(RC3 0.9.3.2)
 Package  | Version  | Link
---|---|---
SDK Core| v0.17.4 | https://www.npmjs.com/package/symbol-sdk
Catbuffer | v0.0.11 | https://www.npmjs.com/package/catbuffer-typescript
Client Library | v0.8.9  | https://www.npmjs.com/package/symbol-openapi-typescript-node-client

- Added `SimpleWallet.toDTO()` method which returns JSON serialized object.
- Applied latest Symbol OpenAPI generated code (`v0.8.9`).
- Added automated release scripts for Travis.
- Added multiple version spport for TS-Doc.
- Optimised unit tests and improved test coverage.
- Changed internal method `getSigningByte` to public.
- Removed constant of namespace `MaxDepth (default: 3)` which can be retrieved from network properties endpoint.
- Fixed Github security alert on `minimist` package.
