### PR TITLE
0.19.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.19.0] - 15-May-2020
+
+**Milestone**: Gorilla.1(0.9.5.1)
+ Package  | Version  | Link
+---|---|---
+SDK Core| v0.19.0 | https://www.npmjs.com/package/symbol-sdk
+Catbuffer | v0.0.18 | https://www.npmjs.com/package/catbuffer-typescript
+Client Library | v0.8.10  | https://www.npmjs.com/package/symbol-openapi-typescript-node-client
+
+- **[BREAKING CHANGE]** `Transaction signing` is now using `GenerationHashSeed` from `NodeInfo` or `NetworkProperties`. GenerationHash on Nemesis block (block:1) is `NOT` used for signing purposes.
+- **[BREAKING CHANGE]** Renamed `AccountLinkTransaction` to `AccountKeyLinkTransaction`.
+- **[BREAKING CHANGE]** Renamed `networkGenerationHash` to `networkGenerationHashSeed` in `NodeInfo`.
+- **[BREAKING CHANGE]** replaced `linkedPublickKey` with `supplementalAccountKeys` array in `AccountInfo`.
+- Added new transaction `VrfKeyLinkTransaction`.
+- Added new transaction `VotingKeyLinkTransaction`.
+- Added new transaction `NodeKeyLinkTransaction`.
+- Added new properties `proofGamma`, `proofScalar`, `proofVarificationHash` in `BlockInfo`
+- Added new properties `harvestNetworkPercentage`, `harvestNetworkFeeSinkPublicKey` in `NetworkProperties`.
+- Added new `KeyType`: Unset / Linked / VRF / Voting / Node / All.
+- Added package `shx` for cross-platform building purpose.
+- Fixed `AggregateTransaction.getMaxCosignatures()` to return distinct cosignature set.
+- Fixed a few documentaion issues.
+
 ## [0.18.0] - 20-Apr-2020
 
 **Milestone**: Fushicho.4(RC3 0.9.3.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -483,6 +483,7 @@ Client Library | v0.7.20-alpha.6  | https://www.npmjs.com/package/nem2-sdk-opena
 
 - Initial code release.
 
+[0.19.0]: https://github.com/nemtech/symbol-sdk-typescript-javascript/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/nemtech/symbol-sdk-typescript-javascript/compare/v0.17.4...v0.18.0
 [0.17.4]: https://github.com/nemtech/symbol-sdk-typescript-javascript/compare/v0.17.3...v0.17.4
 [0.17.3]: https://github.com/nemtech/symbol-sdk-typescript-javascript/compare/v0.17.2...v0.17.3

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ The Symbol SDK for TypeScript / JavaScript allows you to develop web, mobile, an
 
 ## Important Notes
 
-### _Fushicho_ Network Compatibility (catapult-server@0.9.3.2)
+### _Gorilla.1_ Network Compatibility (catapult-server@0.9.5.1)
 
-Due to a network upgrade with [catapult-server@Fushicho](https://github.com/nemtech/catapult-server/releases/tag/v0.9.3.2) version, **it is recommended to use this package's 0.18.0 version and upwards to use this package with Fushicho versioned networks**.
+Due to a network upgrade with [catapult-server@Gorilla.1](https://github.com/nemtech/catapult-server/releases/tag/v0.9.5.1) version, **it is recommended to use this package's 0.19.0 version and upwards to use this package with Fushicho versioned networks**.
 
-The upgrade to this package's [version v0.18.0](https://github.com/nemtech/symbol-sdk-typescript-javascript/releases/tag/v0.18.0) is mandatory for **fushicho compatibility**.
+The upgrade to this package's [version v0.19.0](https://github.com/nemtech/symbol-sdk-typescript-javascript/releases/tag/v0.19.0) is mandatory for **fushicho compatibility**.
 
 Find the complete release notes [here](CHANGELOG.md).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "symbol-sdk",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "symbol-sdk",
-    "version": "0.18.1",
+    "version": "0.19.0",
     "description": "Reactive symbol sdk for typescript and javascript",
     "scripts": {
         "pretest": "npm run build",


### PR DESCRIPTION
## [0.19.0] - 15-May-2020

**Milestone**: Gorilla.1(0.9.5.1)
 Package  | Version  | Link
---|---|---
SDK Core| v0.19.0 | https://www.npmjs.com/package/symbol-sdk
Catbuffer | v0.0.18 | https://www.npmjs.com/package/catbuffer-typescript
Client Library | v0.8.10  | https://www.npmjs.com/package/symbol-openapi-typescript-node-client

- **[BREAKING CHANGE]** `Transaction signing` is now using `GenerationHashSeed` from `NodeInfo` or `NetworkProperties`. GenerationHash on Nemesis block (block:1) is `NOT` used for signing purposes.
- **[BREAKING CHANGE]** Renamed `AccountLinkTransaction` to `AccountKeyLinkTransaction`.
- **[BREAKING CHANGE]** Renamed `networkGenerationHash` to `networkGenerationHashSeed` in `NodeInfo`.
- **[BREAKING CHANGE]** replaced `linkedPublickKey` with `supplementalAccountKeys` array in `AccountInfo`.
- Added new transaction `VrfKeyLinkTransaction`.
- Added new transaction `VotingKeyLinkTransaction`.
- Added new transaction `NodeKeyLinkTransaction`.
- Added new properties `proofGamma`, `proofScalar`, `proofVarificationHash` in `BlockInfo`
- Added new properties `harvestNetworkPercentage`, `harvestNetworkFeeSinkPublicKey` in `NetworkProperties`.
- Added new `KeyType`: Unset / Linked / VRF / Voting / Node / All.
- Added package `shx` for cross-platform building purpose.
- Fixed `AggregateTransaction.getMaxCosignatures()` to return distinct cosignature set.
- Fixed a few documentaion issues.
