### PR TITLE
Listener (WS) refactoring

### DIFF
--- a/src/infrastructure/BlockHttp.ts
+++ b/src/infrastructure/BlockHttp.ts
@@ -55,7 +55,7 @@ export class BlockHttp extends Http implements BlockRepository {
      * @returns Observable<BlockInfo>
      */
     public getBlockByHeight(height: UInt64): Observable<BlockInfo> {
-        return this.call(this.blockRoutesApi.getBlockByHeight(height.toString()), (body) => this.toBlockInfo(body));
+        return this.call(this.blockRoutesApi.getBlockByHeight(height.toString()), (body) => BlockHttp.toBlockInfo(body));
     }
 
     /**
@@ -87,7 +87,7 @@ export class BlockHttp extends Http implements BlockRepository {
      */
     public getBlocksByHeightWithLimit(height: UInt64, limit: number): Observable<BlockInfo[]> {
         return this.call(this.blockRoutesApi.getBlocksByHeightWithLimit(height.toString(), limit), (body) =>
-            body.map((blockDTO) => this.toBlockInfo(blockDTO)),
+            body.map((blockDTO) => BlockHttp.toBlockInfo(blockDTO)),
         );
     }
 
@@ -98,7 +98,7 @@ export class BlockHttp extends Http implements BlockRepository {
      * @param {BlockInfoDTO} dto the dto object from rest.
      * @returns {BlockInfo} a BlockInfo model
      */
-    private toBlockInfo(dto: BlockInfoDTO): BlockInfo {
+    public static toBlockInfo(dto: BlockInfoDTO): BlockInfo {
         const networkType = dto.block.network.valueOf();
         return new BlockInfo(
             dto.meta.hash,

--- a/src/infrastructure/IListener.ts
+++ b/src/infrastructure/IListener.ts
@@ -71,9 +71,10 @@ export interface IListener {
      * it emits a new Transaction in the event stream.
      *
      * @param address address we listen when a transaction is in unconfirmed state
+     * @param transactionHash transactionHash for filtering multiple transactions
      * @return an observable stream of Transaction with state unconfirmed
      */
-    unconfirmedAdded(address: Address): Observable<Transaction>;
+    unconfirmedAdded(address: Address, transactionHash?: string): Observable<Transaction>;
 
     /**
      * Returns an observable stream of Transaction Hashes for specific address.
@@ -81,9 +82,10 @@ export interface IListener {
      * it emits a new message with the transaction hash in the event stream.
      *
      * @param address address we listen when a transaction is removed from unconfirmed state
+     * @param transactionHash the transaction hash filter.
      * @return an observable stream of Strings with the transaction hash
      */
-    unconfirmedRemoved(address: Address): Observable<string>;
+    unconfirmedRemoved(address: Address, transactionHash?: string): Observable<string>;
 
     /**
      * Return an observable of {@link AggregateTransaction} for specific address.
@@ -102,9 +104,10 @@ export interface IListener {
      * it emits a new message with the transaction hash in the event stream.
      *
      * @param address address we listen when a transaction is confirmed or rejected
+     * @param transactionHash the transaction hash filter.
      * @return an observable stream of Strings with the transaction hash
      */
-    aggregateBondedRemoved(address: Address): Observable<string>;
+    aggregateBondedRemoved(address: Address, transactionHash?: string): Observable<string>;
 
     /**
      * Returns an observable stream of {@link TransactionStatusError} for specific address.
@@ -112,9 +115,10 @@ export interface IListener {
      * it emits a new message with the transaction status error in the event stream.
      *
      * @param address address we listen to be notified when some error happened
+     * @param transactionHash transactionHash for filtering multiple transactions
      * @return an observable stream of {@link TransactionStatusError}
      */
-    status(address: Address): Observable<TransactionStatusError>;
+    status(address: Address, transactionHash?: string): Observable<TransactionStatusError>;
 
     /**
      * Returns an observable stream of {@link CosignatureSignedTransaction} for specific address.

--- a/src/infrastructure/Listener.ts
+++ b/src/infrastructure/Listener.ts
@@ -369,7 +369,7 @@ export class Listener implements IListener {
                         }),
                     );
                     return namespaceIdsObservable.pipe(
-                        filter((namespaceIds) => transaction.shouldNotifiAccount(address, namespaceIds)),
+                        filter((namespaceIds) => transaction.shouldNotifyAccount(address, namespaceIds)),
                         map(() => transaction),
                     );
                 }),

--- a/src/infrastructure/Listener.ts
+++ b/src/infrastructure/Listener.ts
@@ -358,7 +358,7 @@ export class Listener implements IListener {
         return (transactionObservable): Observable<T> => {
             return transactionObservable.pipe(
                 flatMap((transaction) => {
-                    if (this.isSigned(transaction, address)) {
+                    if (transaction.isSigned(address)) {
                         return of(transaction);
                     }
                     const namespaceIdsObservable = this.namespaceRepository.getAccountsNames([address]).pipe(
@@ -369,21 +369,12 @@ export class Listener implements IListener {
                         }),
                     );
                     return namespaceIdsObservable.pipe(
-                        filter((namespaceIds) => transaction.NotifyAccount(address, namespaceIds)),
+                        filter((namespaceIds) => transaction.shouldNotifiAccount(address, namespaceIds)),
                         map(() => transaction),
                     );
                 }),
             );
         };
-    }
-
-    /**
-     * Checks if the transaction is signer by an address.
-     * @param transition the transaction
-     * @param address the address.
-     */
-    private isSigned(transition: Transaction, address: Address): boolean {
-        return transition.signer !== undefined && transition.signer!.address.equals(address);
     }
 
     /**

--- a/src/infrastructure/RepositoryFactoryHttp.ts
+++ b/src/infrastructure/RepositoryFactoryHttp.ts
@@ -134,6 +134,6 @@ export class RepositoryFactoryHttp implements RepositoryFactory {
     }
 
     createListener(): IListener {
-        return new Listener(this.url);
+        return new Listener(this.url, this.createNamespaceRepository());
     }
 }

--- a/src/model/transaction/AccountAddressRestrictionTransaction.ts
+++ b/src/model/transaction/AccountAddressRestrictionTransaction.ts
@@ -236,9 +236,9 @@ export class AccountAddressRestrictionTransaction extends Transaction {
      * @param alias address alias (names)
      * @returns {boolean}
      */
-    public NotifyAccount(address: Address, alias: NamespaceId[]): boolean {
+    public shouldNotifiAccount(address: Address, alias: NamespaceId[]): boolean {
         return (
-            (this.signer !== undefined && this.signer!.address.equals(address)) ||
+            super.isSigned(address) ||
             this.restrictionAdditions.find((_) => _.equals(address)) !== undefined ||
             this.restrictionDeletions.find((_) => _.equals(address)) !== undefined ||
             this.restrictionAdditions.find((_: NamespaceId) => alias.find((name) => name.equals(_) !== undefined)) !== undefined ||

--- a/src/model/transaction/AccountAddressRestrictionTransaction.ts
+++ b/src/model/transaction/AccountAddressRestrictionTransaction.ts
@@ -219,4 +219,21 @@ export class AccountAddressRestrictionTransaction extends Transaction {
             ),
         });
     }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @param alias address alias (names)
+     * @returns {boolean}
+     */
+    public NotifyAccount(address: Address, alias: NamespaceId[]): boolean {
+        return (
+            (this.signer !== undefined && this.signer!.address.equals(address)) ||
+            this.restrictionAdditions.find((_) => _.equals(address)) !== undefined ||
+            this.restrictionDeletions.find((_) => _.equals(address)) !== undefined ||
+            this.restrictionAdditions.find((_: NamespaceId) => alias.find((name) => name.equals(_) !== undefined)) !== undefined ||
+            this.restrictionDeletions.find((_: NamespaceId) => alias.find((name) => name.equals(_) !== undefined)) !== undefined
+        );
+    }
 }

--- a/src/model/transaction/AccountAddressRestrictionTransaction.ts
+++ b/src/model/transaction/AccountAddressRestrictionTransaction.ts
@@ -236,7 +236,7 @@ export class AccountAddressRestrictionTransaction extends Transaction {
      * @param alias address alias (names)
      * @returns {boolean}
      */
-    public shouldNotifiAccount(address: Address, alias: NamespaceId[]): boolean {
+    public shouldNotifyAccount(address: Address, alias: NamespaceId[]): boolean {
         return (
             super.isSigned(address) ||
             this.restrictionAdditions.find((_) => _.equals(address)) !== undefined ||

--- a/src/model/transaction/AccountKeyLinkTransaction.ts
+++ b/src/model/transaction/AccountKeyLinkTransaction.ts
@@ -195,7 +195,7 @@ export class AccountKeyLinkTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public shouldNotifiAccount(address: Address): boolean {
+    public shouldNotifyAccount(address: Address): boolean {
         return super.isSigned(address) || Address.createFromPublicKey(this.remotePublicKey, this.networkType).equals(address);
     }
 }

--- a/src/model/transaction/AccountKeyLinkTransaction.ts
+++ b/src/model/transaction/AccountKeyLinkTransaction.ts
@@ -195,10 +195,7 @@ export class AccountKeyLinkTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public NotifyAccount(address: Address): boolean {
-        return (
-            (this.signer !== undefined && this.signer!.address.equals(address)) ||
-            Address.createFromPublicKey(this.remotePublicKey, this.networkType).equals(address)
-        );
+    public shouldNotifiAccount(address: Address): boolean {
+        return super.isSigned(address) || Address.createFromPublicKey(this.remotePublicKey, this.networkType).equals(address);
     }
 }

--- a/src/model/transaction/AccountKeyLinkTransaction.ts
+++ b/src/model/transaction/AccountKeyLinkTransaction.ts
@@ -34,6 +34,7 @@ import { Transaction } from './Transaction';
 import { TransactionInfo } from './TransactionInfo';
 import { TransactionType } from './TransactionType';
 import { TransactionVersion } from './TransactionVersion';
+import { Address } from '../account/Address';
 
 /**
  * Announce an AccountKeyLinkTransaction to delegate the account importance to a proxy account.
@@ -177,5 +178,18 @@ export class AccountKeyLinkTransaction extends Transaction {
      */
     resolveAliases(): AccountKeyLinkTransaction {
         return this;
+    }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @returns {boolean}
+     */
+    public NotifyAccount(address: Address): boolean {
+        return (
+            (this.signer !== undefined && this.signer!.address.equals(address)) ||
+            Address.createFromPublicKey(this.remotePublicKey, this.networkType).equals(address)
+        );
     }
 }

--- a/src/model/transaction/AccountMetadataTransaction.ts
+++ b/src/model/transaction/AccountMetadataTransaction.ts
@@ -33,6 +33,7 @@ import { Transaction } from './Transaction';
 import { TransactionInfo } from './TransactionInfo';
 import { TransactionType } from './TransactionType';
 import { TransactionVersion } from './TransactionVersion';
+import { Address } from '../account/Address';
 
 /**
  * Announce an account metadata transaction to associate a key-value state to an account.
@@ -203,5 +204,18 @@ export class AccountMetadataTransaction extends Transaction {
      */
     resolveAliases(): AccountMetadataTransaction {
         return this;
+    }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @returns {boolean}
+     */
+    public NotifyAccount(address: Address): boolean {
+        return (
+            (this.signer !== undefined && this.signer!.address.equals(address)) ||
+            Address.createFromPublicKey(this.targetPublicKey, this.networkType).equals(address)
+        );
     }
 }

--- a/src/model/transaction/AccountMetadataTransaction.ts
+++ b/src/model/transaction/AccountMetadataTransaction.ts
@@ -221,7 +221,7 @@ export class AccountMetadataTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public shouldNotifiAccount(address: Address): boolean {
+    public shouldNotifyAccount(address: Address): boolean {
         return super.isSigned(address) || Address.createFromPublicKey(this.targetPublicKey, this.networkType).equals(address);
     }
 }

--- a/src/model/transaction/AccountMetadataTransaction.ts
+++ b/src/model/transaction/AccountMetadataTransaction.ts
@@ -221,10 +221,7 @@ export class AccountMetadataTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public NotifyAccount(address: Address): boolean {
-        return (
-            (this.signer !== undefined && this.signer!.address.equals(address)) ||
-            Address.createFromPublicKey(this.targetPublicKey, this.networkType).equals(address)
-        );
+    public shouldNotifiAccount(address: Address): boolean {
+        return super.isSigned(address) || Address.createFromPublicKey(this.targetPublicKey, this.networkType).equals(address);
     }
 }

--- a/src/model/transaction/AccountMosaicRestrictionTransaction.ts
+++ b/src/model/transaction/AccountMosaicRestrictionTransaction.ts
@@ -236,7 +236,7 @@ export class AccountMosaicRestrictionTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public NotifyAccount(address: Address): boolean {
+    public shouldNotifiAccount(address: Address): boolean {
         return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/AccountMosaicRestrictionTransaction.ts
+++ b/src/model/transaction/AccountMosaicRestrictionTransaction.ts
@@ -40,6 +40,7 @@ import { Transaction } from './Transaction';
 import { TransactionInfo } from './TransactionInfo';
 import { TransactionType } from './TransactionType';
 import { TransactionVersion } from './TransactionVersion';
+import { Address } from '../account/Address';
 
 export class AccountMosaicRestrictionTransaction extends Transaction {
     /**
@@ -218,5 +219,15 @@ export class AccountMosaicRestrictionTransaction extends Transaction {
                 statement.resolveMosaicId(deletion, transactionInfo.height.toString(), transactionInfo.index, aggregateTransactionIndex),
             ),
         });
+    }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @returns {boolean}
+     */
+    public NotifyAccount(address: Address): boolean {
+        return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/AccountMosaicRestrictionTransaction.ts
+++ b/src/model/transaction/AccountMosaicRestrictionTransaction.ts
@@ -236,7 +236,7 @@ export class AccountMosaicRestrictionTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public shouldNotifiAccount(address: Address): boolean {
+    public shouldNotifyAccount(address: Address): boolean {
         return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/AccountMosaicRestrictionTransaction.ts
+++ b/src/model/transaction/AccountMosaicRestrictionTransaction.ts
@@ -237,6 +237,6 @@ export class AccountMosaicRestrictionTransaction extends Transaction {
      * @returns {boolean}
      */
     public shouldNotifyAccount(address: Address): boolean {
-        return this.signer !== undefined && this.signer!.address.equals(address);
+        return super.isSigned(address);
     }
 }

--- a/src/model/transaction/AccountOperationRestrictionTransaction.ts
+++ b/src/model/transaction/AccountOperationRestrictionTransaction.ts
@@ -34,6 +34,7 @@ import { Transaction } from './Transaction';
 import { TransactionInfo } from './TransactionInfo';
 import { TransactionType } from './TransactionType';
 import { TransactionVersion } from './TransactionVersion';
+import { Address } from '../account/Address';
 
 export class AccountOperationRestrictionTransaction extends Transaction {
     /**
@@ -190,5 +191,15 @@ export class AccountOperationRestrictionTransaction extends Transaction {
      */
     resolveAliases(): AccountOperationRestrictionTransaction {
         return this;
+    }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @returns {boolean}
+     */
+    public NotifyAccount(address: Address): boolean {
+        return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/AccountOperationRestrictionTransaction.ts
+++ b/src/model/transaction/AccountOperationRestrictionTransaction.ts
@@ -208,7 +208,7 @@ export class AccountOperationRestrictionTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public NotifyAccount(address: Address): boolean {
+    public shouldNotifiAccount(address: Address): boolean {
         return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/AccountOperationRestrictionTransaction.ts
+++ b/src/model/transaction/AccountOperationRestrictionTransaction.ts
@@ -208,7 +208,7 @@ export class AccountOperationRestrictionTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public shouldNotifiAccount(address: Address): boolean {
+    public shouldNotifyAccount(address: Address): boolean {
         return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/AccountOperationRestrictionTransaction.ts
+++ b/src/model/transaction/AccountOperationRestrictionTransaction.ts
@@ -209,6 +209,6 @@ export class AccountOperationRestrictionTransaction extends Transaction {
      * @returns {boolean}
      */
     public shouldNotifyAccount(address: Address): boolean {
-        return this.signer !== undefined && this.signer!.address.equals(address);
+        return super.isSigned(address);
     }
 }

--- a/src/model/transaction/AddressAliasTransaction.ts
+++ b/src/model/transaction/AddressAliasTransaction.ts
@@ -195,4 +195,14 @@ export class AddressAliasTransaction extends Transaction {
     resolveAliases(): AddressAliasTransaction {
         return this;
     }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @returns {boolean}
+     */
+    public NotifyAccount(address: Address): boolean {
+        return (this.signer !== undefined && this.signer!.address.equals(address)) || this.address.equals(address);
+    }
 }

--- a/src/model/transaction/AddressAliasTransaction.ts
+++ b/src/model/transaction/AddressAliasTransaction.ts
@@ -211,7 +211,7 @@ export class AddressAliasTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public NotifyAccount(address: Address): boolean {
-        return (this.signer !== undefined && this.signer!.address.equals(address)) || this.address.equals(address);
+    public shouldNotifiAccount(address: Address): boolean {
+        return super.isSigned(address) || this.address.equals(address);
     }
 }

--- a/src/model/transaction/AddressAliasTransaction.ts
+++ b/src/model/transaction/AddressAliasTransaction.ts
@@ -211,7 +211,7 @@ export class AddressAliasTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public shouldNotifiAccount(address: Address): boolean {
+    public shouldNotifyAccount(address: Address): boolean {
         return super.isSigned(address) || this.address.equals(address);
     }
 }

--- a/src/model/transaction/AggregateTransaction.ts
+++ b/src/model/transaction/AggregateTransaction.ts
@@ -45,6 +45,8 @@ import { Transaction } from './Transaction';
 import { TransactionInfo } from './TransactionInfo';
 import { TransactionType } from './TransactionType';
 import { TransactionVersion } from './TransactionVersion';
+import { Address } from '../account/Address';
+import { NamespaceId } from '../namespace/NamespaceId';
 
 /**
  * Aggregate innerTransactions contain multiple innerTransactions that can be initiated by different accounts.
@@ -420,5 +422,21 @@ export class AggregateTransaction extends Transaction {
         return DtoMapping.assign(this, {
             maxFee: UInt64.fromUint(calculatedSize * feeMultiplier),
         });
+    }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @param alias address alias (names)
+     * @returns {boolean}
+     */
+    public NotifyAccount(address: Address, alias: NamespaceId[]): boolean {
+        return (
+            (this.signer !== undefined && this.signer!.address.equals(address)) ||
+            this.cosignatures.find((_) => _.signer.address.equals(address)) !== undefined ||
+            this.innerTransactions.find((innerTransaction: InnerTransaction) => innerTransaction.NotifyAccount(address, alias)) !==
+                undefined
+        );
     }
 }

--- a/src/model/transaction/AggregateTransaction.ts
+++ b/src/model/transaction/AggregateTransaction.ts
@@ -449,11 +449,11 @@ export class AggregateTransaction extends Transaction {
      * @param alias address alias (names)
      * @returns {boolean}
      */
-    public NotifyAccount(address: Address, alias: NamespaceId[]): boolean {
+    public shouldNotifiAccount(address: Address, alias: NamespaceId[]): boolean {
         return (
-            (this.signer !== undefined && this.signer!.address.equals(address)) ||
+            super.isSigned(address) ||
             this.cosignatures.find((_) => _.signer.address.equals(address)) !== undefined ||
-            this.innerTransactions.find((innerTransaction: InnerTransaction) => innerTransaction.NotifyAccount(address, alias)) !==
+            this.innerTransactions.find((innerTransaction: InnerTransaction) => innerTransaction.shouldNotifiAccount(address, alias)) !==
                 undefined
         );
     }

--- a/src/model/transaction/AggregateTransaction.ts
+++ b/src/model/transaction/AggregateTransaction.ts
@@ -449,11 +449,11 @@ export class AggregateTransaction extends Transaction {
      * @param alias address alias (names)
      * @returns {boolean}
      */
-    public shouldNotifiAccount(address: Address, alias: NamespaceId[]): boolean {
+    public shouldNotifyAccount(address: Address, alias: NamespaceId[]): boolean {
         return (
             super.isSigned(address) ||
             this.cosignatures.find((_) => _.signer.address.equals(address)) !== undefined ||
-            this.innerTransactions.find((innerTransaction: InnerTransaction) => innerTransaction.shouldNotifiAccount(address, alias)) !==
+            this.innerTransactions.find((innerTransaction: InnerTransaction) => innerTransaction.shouldNotifyAccount(address, alias)) !==
                 undefined
         );
     }

--- a/src/model/transaction/LockFundsTransaction.ts
+++ b/src/model/transaction/LockFundsTransaction.ts
@@ -237,7 +237,7 @@ export class LockFundsTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public NotifyAccount(address: Address): boolean {
+    public shouldNotifiAccount(address: Address): boolean {
         return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/LockFundsTransaction.ts
+++ b/src/model/transaction/LockFundsTransaction.ts
@@ -238,6 +238,6 @@ export class LockFundsTransaction extends Transaction {
      * @returns {boolean}
      */
     public shouldNotifyAccount(address: Address): boolean {
-        return this.signer !== undefined && this.signer!.address.equals(address);
+        return super.isSigned(address);
     }
 }

--- a/src/model/transaction/LockFundsTransaction.ts
+++ b/src/model/transaction/LockFundsTransaction.ts
@@ -42,6 +42,7 @@ import { Transaction } from './Transaction';
 import { TransactionInfo } from './TransactionInfo';
 import { TransactionType } from './TransactionType';
 import { TransactionVersion } from './TransactionVersion';
+import { Address } from '../account/Address';
 
 /**
  * Lock funds transaction is used before sending an Aggregate bonded transaction, as a deposit to announce the transaction.
@@ -211,5 +212,15 @@ export class LockFundsTransaction extends Transaction {
                 aggregateTransactionIndex,
             ),
         });
+    }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @returns {boolean}
+     */
+    public NotifyAccount(address: Address): boolean {
+        return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/LockFundsTransaction.ts
+++ b/src/model/transaction/LockFundsTransaction.ts
@@ -237,7 +237,7 @@ export class LockFundsTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public shouldNotifiAccount(address: Address): boolean {
+    public shouldNotifyAccount(address: Address): boolean {
         return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/MosaicAddressRestrictionTransaction.ts
+++ b/src/model/transaction/MosaicAddressRestrictionTransaction.ts
@@ -261,4 +261,19 @@ export class MosaicAddressRestrictionTransaction extends Transaction {
             ),
         });
     }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @param alias address alias (names)
+     * @returns {boolean}
+     */
+    public NotifyAccount(address: Address, alias: NamespaceId[]): boolean {
+        return (
+            (this.signer !== undefined && this.signer!.address.equals(address)) ||
+            (this.targetAddress as Address).equals(address) ||
+            alias.find((name) => (this.targetAddress as NamespaceId).equals(name)) !== undefined
+        );
+    }
 }

--- a/src/model/transaction/MosaicAddressRestrictionTransaction.ts
+++ b/src/model/transaction/MosaicAddressRestrictionTransaction.ts
@@ -278,9 +278,9 @@ export class MosaicAddressRestrictionTransaction extends Transaction {
      * @param alias address alias (names)
      * @returns {boolean}
      */
-    public NotifyAccount(address: Address, alias: NamespaceId[]): boolean {
+    public shouldNotifiAccount(address: Address, alias: NamespaceId[]): boolean {
         return (
-            (this.signer !== undefined && this.signer!.address.equals(address)) ||
+            super.isSigned(address) ||
             (this.targetAddress as Address).equals(address) ||
             alias.find((name) => (this.targetAddress as NamespaceId).equals(name)) !== undefined
         );

--- a/src/model/transaction/MosaicAddressRestrictionTransaction.ts
+++ b/src/model/transaction/MosaicAddressRestrictionTransaction.ts
@@ -278,7 +278,7 @@ export class MosaicAddressRestrictionTransaction extends Transaction {
      * @param alias address alias (names)
      * @returns {boolean}
      */
-    public shouldNotifiAccount(address: Address, alias: NamespaceId[]): boolean {
+    public shouldNotifyAccount(address: Address, alias: NamespaceId[]): boolean {
         return (
             super.isSigned(address) ||
             (this.targetAddress as Address).equals(address) ||

--- a/src/model/transaction/MosaicAliasTransaction.ts
+++ b/src/model/transaction/MosaicAliasTransaction.ts
@@ -208,7 +208,7 @@ export class MosaicAliasTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public shouldNotifiAccount(address: Address): boolean {
+    public shouldNotifyAccount(address: Address): boolean {
         return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/MosaicAliasTransaction.ts
+++ b/src/model/transaction/MosaicAliasTransaction.ts
@@ -208,7 +208,7 @@ export class MosaicAliasTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public NotifyAccount(address: Address): boolean {
+    public shouldNotifiAccount(address: Address): boolean {
         return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/MosaicAliasTransaction.ts
+++ b/src/model/transaction/MosaicAliasTransaction.ts
@@ -209,6 +209,6 @@ export class MosaicAliasTransaction extends Transaction {
      * @returns {boolean}
      */
     public shouldNotifyAccount(address: Address): boolean {
-        return this.signer !== undefined && this.signer!.address.equals(address);
+        return super.isSigned(address);
     }
 }

--- a/src/model/transaction/MosaicAliasTransaction.ts
+++ b/src/model/transaction/MosaicAliasTransaction.ts
@@ -38,6 +38,7 @@ import { Transaction } from './Transaction';
 import { TransactionInfo } from './TransactionInfo';
 import { TransactionType } from './TransactionType';
 import { TransactionVersion } from './TransactionVersion';
+import { Address } from '../account/Address';
 
 export class MosaicAliasTransaction extends Transaction {
     /**
@@ -190,5 +191,15 @@ export class MosaicAliasTransaction extends Transaction {
      */
     resolveAliases(): MosaicAliasTransaction {
         return this;
+    }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @returns {boolean}
+     */
+    public NotifyAccount(address: Address): boolean {
+        return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/MosaicDefinitionTransaction.ts
+++ b/src/model/transaction/MosaicDefinitionTransaction.ts
@@ -248,7 +248,7 @@ export class MosaicDefinitionTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public shouldNotifiAccount(address: Address): boolean {
+    public shouldNotifyAccount(address: Address): boolean {
         return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/MosaicDefinitionTransaction.ts
+++ b/src/model/transaction/MosaicDefinitionTransaction.ts
@@ -249,6 +249,6 @@ export class MosaicDefinitionTransaction extends Transaction {
      * @returns {boolean}
      */
     public shouldNotifyAccount(address: Address): boolean {
-        return this.signer !== undefined && this.signer!.address.equals(address);
+        return super.isSigned(address);
     }
 }

--- a/src/model/transaction/MosaicDefinitionTransaction.ts
+++ b/src/model/transaction/MosaicDefinitionTransaction.ts
@@ -248,7 +248,7 @@ export class MosaicDefinitionTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public NotifyAccount(address: Address): boolean {
+    public shouldNotifiAccount(address: Address): boolean {
         return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/MosaicDefinitionTransaction.ts
+++ b/src/model/transaction/MosaicDefinitionTransaction.ts
@@ -39,6 +39,7 @@ import { Transaction } from './Transaction';
 import { TransactionInfo } from './TransactionInfo';
 import { TransactionType } from './TransactionType';
 import { TransactionVersion } from './TransactionVersion';
+import { Address } from '../account/Address';
 
 /**
  * Before a mosaic can be created or transferred, a corresponding definition of the mosaic has to be created and published to the network.
@@ -230,5 +231,15 @@ export class MosaicDefinitionTransaction extends Transaction {
      */
     resolveAliases(): MosaicDefinitionTransaction {
         return this;
+    }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @returns {boolean}
+     */
+    public NotifyAccount(address: Address): boolean {
+        return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/MosaicGlobalRestrictionTransaction.ts
+++ b/src/model/transaction/MosaicGlobalRestrictionTransaction.ts
@@ -40,6 +40,7 @@ import { Transaction } from './Transaction';
 import { TransactionInfo } from './TransactionInfo';
 import { TransactionType } from './TransactionType';
 import { TransactionVersion } from './TransactionVersion';
+import { Address } from '../account/Address';
 
 export class MosaicGlobalRestrictionTransaction extends Transaction {
     /**
@@ -279,5 +280,15 @@ export class MosaicGlobalRestrictionTransaction extends Transaction {
                 aggregateTransactionIndex,
             ),
         });
+    }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @returns {boolean}
+     */
+    public NotifyAccount(address: Address): boolean {
+        return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/MosaicGlobalRestrictionTransaction.ts
+++ b/src/model/transaction/MosaicGlobalRestrictionTransaction.ts
@@ -298,6 +298,6 @@ export class MosaicGlobalRestrictionTransaction extends Transaction {
      * @returns {boolean}
      */
     public shouldNotifyAccount(address: Address): boolean {
-        return this.signer !== undefined && this.signer!.address.equals(address);
+        return super.isSigned(address);
     }
 }

--- a/src/model/transaction/MosaicGlobalRestrictionTransaction.ts
+++ b/src/model/transaction/MosaicGlobalRestrictionTransaction.ts
@@ -297,7 +297,7 @@ export class MosaicGlobalRestrictionTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public shouldNotifiAccount(address: Address): boolean {
+    public shouldNotifyAccount(address: Address): boolean {
         return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/MosaicGlobalRestrictionTransaction.ts
+++ b/src/model/transaction/MosaicGlobalRestrictionTransaction.ts
@@ -297,7 +297,7 @@ export class MosaicGlobalRestrictionTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public NotifyAccount(address: Address): boolean {
+    public shouldNotifiAccount(address: Address): boolean {
         return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/MosaicMetadataTransaction.ts
+++ b/src/model/transaction/MosaicMetadataTransaction.ts
@@ -249,7 +249,7 @@ export class MosaicMetadataTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public shouldNotifiAccount(address: Address): boolean {
+    public shouldNotifyAccount(address: Address): boolean {
         return super.isSigned(address) || Address.createFromPublicKey(this.targetPublicKey, this.networkType).equals(address);
     }
 }

--- a/src/model/transaction/MosaicMetadataTransaction.ts
+++ b/src/model/transaction/MosaicMetadataTransaction.ts
@@ -39,6 +39,7 @@ import { Transaction } from './Transaction';
 import { TransactionInfo } from './TransactionInfo';
 import { TransactionType } from './TransactionType';
 import { TransactionVersion } from './TransactionVersion';
+import { Address } from '../account/Address';
 
 /**
  * Announce an mosaic metadata transaction to associate a key-value state to an account.
@@ -231,5 +232,18 @@ export class MosaicMetadataTransaction extends Transaction {
                 aggregateTransactionIndex,
             ),
         });
+    }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @returns {boolean}
+     */
+    public NotifyAccount(address: Address): boolean {
+        return (
+            (this.signer !== undefined && this.signer!.address.equals(address)) ||
+            Address.createFromPublicKey(this.targetPublicKey, this.networkType).equals(address)
+        );
     }
 }

--- a/src/model/transaction/MosaicMetadataTransaction.ts
+++ b/src/model/transaction/MosaicMetadataTransaction.ts
@@ -249,10 +249,7 @@ export class MosaicMetadataTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public NotifyAccount(address: Address): boolean {
-        return (
-            (this.signer !== undefined && this.signer!.address.equals(address)) ||
-            Address.createFromPublicKey(this.targetPublicKey, this.networkType).equals(address)
-        );
+    public shouldNotifiAccount(address: Address): boolean {
+        return super.isSigned(address) || Address.createFromPublicKey(this.targetPublicKey, this.networkType).equals(address);
     }
 }

--- a/src/model/transaction/MosaicSupplyChangeTransaction.ts
+++ b/src/model/transaction/MosaicSupplyChangeTransaction.ts
@@ -226,7 +226,7 @@ export class MosaicSupplyChangeTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public shouldNotifiAccount(address: Address): boolean {
+    public shouldNotifyAccount(address: Address): boolean {
         return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/MosaicSupplyChangeTransaction.ts
+++ b/src/model/transaction/MosaicSupplyChangeTransaction.ts
@@ -227,6 +227,6 @@ export class MosaicSupplyChangeTransaction extends Transaction {
      * @returns {boolean}
      */
     public shouldNotifyAccount(address: Address): boolean {
-        return this.signer !== undefined && this.signer!.address.equals(address);
+        return super.isSigned(address);
     }
 }

--- a/src/model/transaction/MosaicSupplyChangeTransaction.ts
+++ b/src/model/transaction/MosaicSupplyChangeTransaction.ts
@@ -40,6 +40,7 @@ import { Transaction } from './Transaction';
 import { TransactionInfo } from './TransactionInfo';
 import { TransactionType } from './TransactionType';
 import { TransactionVersion } from './TransactionVersion';
+import { Address } from '../account/Address';
 
 /**
  * In case a mosaic has the flag 'supplyMutable' set to true, the creator of the mosaic can change the supply,
@@ -208,5 +209,15 @@ export class MosaicSupplyChangeTransaction extends Transaction {
                 aggregateTransactionIndex,
             ),
         });
+    }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @returns {boolean}
+     */
+    public NotifyAccount(address: Address): boolean {
+        return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/MosaicSupplyChangeTransaction.ts
+++ b/src/model/transaction/MosaicSupplyChangeTransaction.ts
@@ -226,7 +226,7 @@ export class MosaicSupplyChangeTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public NotifyAccount(address: Address): boolean {
+    public shouldNotifiAccount(address: Address): boolean {
         return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/MultisigAccountModificationTransaction.ts
+++ b/src/model/transaction/MultisigAccountModificationTransaction.ts
@@ -249,7 +249,7 @@ export class MultisigAccountModificationTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public shouldNotifiAccount(address: Address): boolean {
+    public shouldNotifyAccount(address: Address): boolean {
         return (
             super.isSigned(address) ||
             this.publicKeyAdditions.find((_: PublicAccount) => _.address.equals(address)) !== undefined ||

--- a/src/model/transaction/MultisigAccountModificationTransaction.ts
+++ b/src/model/transaction/MultisigAccountModificationTransaction.ts
@@ -33,6 +33,7 @@ import { Transaction } from './Transaction';
 import { TransactionInfo } from './TransactionInfo';
 import { TransactionType } from './TransactionType';
 import { TransactionVersion } from './TransactionVersion';
+import { Address } from '../account/Address';
 
 /**
  * Modify multisig account transactions are part of the NEM's multisig account system.
@@ -231,5 +232,19 @@ export class MultisigAccountModificationTransaction extends Transaction {
      */
     resolveAliases(): MultisigAccountModificationTransaction {
         return this;
+    }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @returns {boolean}
+     */
+    public NotifyAccount(address: Address): boolean {
+        return (
+            (this.signer !== undefined && this.signer!.address.equals(address)) ||
+            this.publicKeyAdditions.find((_: PublicAccount) => _.address.equals(address)) !== undefined ||
+            this.publicKeyDeletions.find((_: PublicAccount) => _.address.equals(address)) !== undefined
+        );
     }
 }

--- a/src/model/transaction/MultisigAccountModificationTransaction.ts
+++ b/src/model/transaction/MultisigAccountModificationTransaction.ts
@@ -249,9 +249,9 @@ export class MultisigAccountModificationTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public NotifyAccount(address: Address): boolean {
+    public shouldNotifiAccount(address: Address): boolean {
         return (
-            (this.signer !== undefined && this.signer!.address.equals(address)) ||
+            super.isSigned(address) ||
             this.publicKeyAdditions.find((_: PublicAccount) => _.address.equals(address)) !== undefined ||
             this.publicKeyDeletions.find((_: PublicAccount) => _.address.equals(address)) !== undefined
         );

--- a/src/model/transaction/NamespaceMetadataTransaction.ts
+++ b/src/model/transaction/NamespaceMetadataTransaction.ts
@@ -245,7 +245,7 @@ export class NamespaceMetadataTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public shouldNotifiAccount(address: Address): boolean {
+    public shouldNotifyAccount(address: Address): boolean {
         return super.isSigned(address) || Address.createFromPublicKey(this.targetPublicKey, this.networkType).equals(address);
     }
 }

--- a/src/model/transaction/NamespaceMetadataTransaction.ts
+++ b/src/model/transaction/NamespaceMetadataTransaction.ts
@@ -35,6 +35,7 @@ import { Transaction } from './Transaction';
 import { TransactionInfo } from './TransactionInfo';
 import { TransactionType } from './TransactionType';
 import { TransactionVersion } from './TransactionVersion';
+import { Address } from '../account/Address';
 
 /**
  * Announce an namespace metadata transaction to associate a key-value state to an account.
@@ -227,5 +228,18 @@ export class NamespaceMetadataTransaction extends Transaction {
      */
     resolveAliases(): NamespaceMetadataTransaction {
         return this;
+    }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @returns {boolean}
+     */
+    public NotifyAccount(address: Address): boolean {
+        return (
+            (this.signer !== undefined && this.signer!.address.equals(address)) ||
+            Address.createFromPublicKey(this.targetPublicKey, this.networkType).equals(address)
+        );
     }
 }

--- a/src/model/transaction/NamespaceMetadataTransaction.ts
+++ b/src/model/transaction/NamespaceMetadataTransaction.ts
@@ -245,10 +245,7 @@ export class NamespaceMetadataTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public NotifyAccount(address: Address): boolean {
-        return (
-            (this.signer !== undefined && this.signer!.address.equals(address)) ||
-            Address.createFromPublicKey(this.targetPublicKey, this.networkType).equals(address)
-        );
+    public shouldNotifiAccount(address: Address): boolean {
+        return super.isSigned(address) || Address.createFromPublicKey(this.targetPublicKey, this.networkType).equals(address);
     }
 }

--- a/src/model/transaction/NamespaceRegistrationTransaction.ts
+++ b/src/model/transaction/NamespaceRegistrationTransaction.ts
@@ -315,7 +315,7 @@ export class NamespaceRegistrationTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public NotifyAccount(address: Address): boolean {
+    public shouldNotifiAccount(address: Address): boolean {
         return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/NamespaceRegistrationTransaction.ts
+++ b/src/model/transaction/NamespaceRegistrationTransaction.ts
@@ -38,6 +38,7 @@ import { Transaction } from './Transaction';
 import { TransactionInfo } from './TransactionInfo';
 import { TransactionType } from './TransactionType';
 import { TransactionVersion } from './TransactionVersion';
+import { Address } from '../account/Address';
 
 /**
  * Accounts can rent a namespace for an amount of blocks and after a this renew the contract.
@@ -288,5 +289,15 @@ export class NamespaceRegistrationTransaction extends Transaction {
      */
     resolveAliases(): NamespaceRegistrationTransaction {
         return this;
+    }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @returns {boolean}
+     */
+    public NotifyAccount(address: Address): boolean {
+        return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/NamespaceRegistrationTransaction.ts
+++ b/src/model/transaction/NamespaceRegistrationTransaction.ts
@@ -316,6 +316,6 @@ export class NamespaceRegistrationTransaction extends Transaction {
      * @returns {boolean}
      */
     public shouldNotifyAccount(address: Address): boolean {
-        return this.signer !== undefined && this.signer!.address.equals(address);
+        return super.isSigned(address);
     }
 }

--- a/src/model/transaction/NamespaceRegistrationTransaction.ts
+++ b/src/model/transaction/NamespaceRegistrationTransaction.ts
@@ -315,7 +315,7 @@ export class NamespaceRegistrationTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public shouldNotifiAccount(address: Address): boolean {
+    public shouldNotifyAccount(address: Address): boolean {
         return this.signer !== undefined && this.signer!.address.equals(address);
     }
 }

--- a/src/model/transaction/NodeKeyLinkTransaction.ts
+++ b/src/model/transaction/NodeKeyLinkTransaction.ts
@@ -191,7 +191,7 @@ export class NodeKeyLinkTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public shouldNotifiAccount(address: Address): boolean {
+    public shouldNotifyAccount(address: Address): boolean {
         return super.isSigned(address) || Address.createFromPublicKey(this.linkedPublicKey, this.networkType).equals(address);
     }
 }

--- a/src/model/transaction/NodeKeyLinkTransaction.ts
+++ b/src/model/transaction/NodeKeyLinkTransaction.ts
@@ -34,6 +34,7 @@ import { Transaction } from './Transaction';
 import { TransactionInfo } from './TransactionInfo';
 import { TransactionType } from './TransactionType';
 import { TransactionVersion } from './TransactionVersion';
+import { Address } from '../account/Address';
 
 export class NodeKeyLinkTransaction extends Transaction {
     /**
@@ -166,5 +167,18 @@ export class NodeKeyLinkTransaction extends Transaction {
      */
     resolveAliases(): NodeKeyLinkTransaction {
         return this;
+    }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @returns {boolean}
+     */
+    public NotifyAccount(address: Address): boolean {
+        return (
+            (this.signer !== undefined && this.signer!.address.equals(address)) ||
+            Address.createFromPublicKey(this.linkedPublicKey, this.networkType).equals(address)
+        );
     }
 }

--- a/src/model/transaction/NodeKeyLinkTransaction.ts
+++ b/src/model/transaction/NodeKeyLinkTransaction.ts
@@ -191,10 +191,7 @@ export class NodeKeyLinkTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public NotifyAccount(address: Address): boolean {
-        return (
-            (this.signer !== undefined && this.signer!.address.equals(address)) ||
-            Address.createFromPublicKey(this.linkedPublicKey, this.networkType).equals(address)
-        );
+    public shouldNotifiAccount(address: Address): boolean {
+        return super.isSigned(address) || Address.createFromPublicKey(this.linkedPublicKey, this.networkType).equals(address);
     }
 }

--- a/src/model/transaction/SecretLockTransaction.ts
+++ b/src/model/transaction/SecretLockTransaction.ts
@@ -273,7 +273,7 @@ export class SecretLockTransaction extends Transaction {
      * @param alias address alias (names)
      * @returns {boolean}
      */
-    public shouldNotifiAccount(address: Address, alias: NamespaceId[]): boolean {
+    public shouldNotifyAccount(address: Address, alias: NamespaceId[]): boolean {
         return (
             super.isSigned(address) ||
             (this.recipientAddress as Address).equals(address) ||

--- a/src/model/transaction/SecretLockTransaction.ts
+++ b/src/model/transaction/SecretLockTransaction.ts
@@ -257,4 +257,19 @@ export class SecretLockTransaction extends Transaction {
             ),
         });
     }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @param alias address alias (names)
+     * @returns {boolean}
+     */
+    public NotifyAccount(address: Address, alias: NamespaceId[]): boolean {
+        return (
+            (this.signer !== undefined && this.signer!.address.equals(address)) ||
+            (this.recipientAddress as Address).equals(address) ||
+            alias.find((name) => (this.recipientAddress as NamespaceId).equals(name)) !== undefined
+        );
+    }
 }

--- a/src/model/transaction/SecretLockTransaction.ts
+++ b/src/model/transaction/SecretLockTransaction.ts
@@ -273,9 +273,9 @@ export class SecretLockTransaction extends Transaction {
      * @param alias address alias (names)
      * @returns {boolean}
      */
-    public NotifyAccount(address: Address, alias: NamespaceId[]): boolean {
+    public shouldNotifiAccount(address: Address, alias: NamespaceId[]): boolean {
         return (
-            (this.signer !== undefined && this.signer!.address.equals(address)) ||
+            super.isSigned(address) ||
             (this.recipientAddress as Address).equals(address) ||
             alias.find((name) => (this.recipientAddress as NamespaceId).equals(name)) !== undefined
         );

--- a/src/model/transaction/SecretProofTransaction.ts
+++ b/src/model/transaction/SecretProofTransaction.ts
@@ -246,7 +246,7 @@ export class SecretProofTransaction extends Transaction {
      * @param alias address alias (names)
      * @returns {boolean}
      */
-    public shouldNotifiAccount(address: Address, alias: NamespaceId[]): boolean {
+    public shouldNotifyAccount(address: Address, alias: NamespaceId[]): boolean {
         return (
             super.isSigned(address) ||
             (this.recipientAddress as Address).equals(address) ||

--- a/src/model/transaction/SecretProofTransaction.ts
+++ b/src/model/transaction/SecretProofTransaction.ts
@@ -246,9 +246,9 @@ export class SecretProofTransaction extends Transaction {
      * @param alias address alias (names)
      * @returns {boolean}
      */
-    public NotifyAccount(address: Address, alias: NamespaceId[]): boolean {
+    public shouldNotifiAccount(address: Address, alias: NamespaceId[]): boolean {
         return (
-            (this.signer !== undefined && this.signer!.address.equals(address)) ||
+            super.isSigned(address) ||
             (this.recipientAddress as Address).equals(address) ||
             alias.find((name) => (this.recipientAddress as NamespaceId).equals(name)) !== undefined
         );

--- a/src/model/transaction/SecretProofTransaction.ts
+++ b/src/model/transaction/SecretProofTransaction.ts
@@ -230,4 +230,19 @@ export class SecretProofTransaction extends Transaction {
             ),
         });
     }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @param alias address alias (names)
+     * @returns {boolean}
+     */
+    public NotifyAccount(address: Address, alias: NamespaceId[]): boolean {
+        return (
+            (this.signer !== undefined && this.signer!.address.equals(address)) ||
+            (this.recipientAddress as Address).equals(address) ||
+            alias.find((name) => (this.recipientAddress as NamespaceId).equals(name)) !== undefined
+        );
+    }
 }

--- a/src/model/transaction/Transaction.ts
+++ b/src/model/transaction/Transaction.ts
@@ -30,6 +30,8 @@ import { InnerTransaction } from './InnerTransaction';
 import { SignedTransaction } from './SignedTransaction';
 import { TransactionInfo } from './TransactionInfo';
 import { TransactionType } from './TransactionType';
+import { NamespaceId } from '../namespace/NamespaceId';
+import { Address } from '../account/Address';
 
 /**
  * An abstract transaction class that serves as the base class of all NEM transactions.
@@ -430,4 +432,13 @@ export abstract class Transaction {
         }
         return this.transactionInfo;
     }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @param alias address alias (names)
+     * @returns {boolean}
+     */
+    public abstract NotifyAccount(address: Address, alias?: NamespaceId[]): boolean;
 }

--- a/src/model/transaction/Transaction.ts
+++ b/src/model/transaction/Transaction.ts
@@ -440,5 +440,14 @@ export abstract class Transaction {
      * @param alias address alias (names)
      * @returns {boolean}
      */
-    public abstract NotifyAccount(address: Address, alias?: NamespaceId[]): boolean;
+    public abstract shouldNotifiAccount(address: Address, alias?: NamespaceId[]): boolean;
+
+    /**
+     * @internal
+     * Checks if the transaction is signer by an address.
+     * @param address the address.
+     */
+    public isSigned(address: Address): boolean {
+        return this.signer !== undefined && this.signer!.address.equals(address);
+    }
 }

--- a/src/model/transaction/Transaction.ts
+++ b/src/model/transaction/Transaction.ts
@@ -440,7 +440,7 @@ export abstract class Transaction {
      * @param alias address alias (names)
      * @returns {boolean}
      */
-    public abstract shouldNotifiAccount(address: Address, alias?: NamespaceId[]): boolean;
+    public abstract shouldNotifyAccount(address: Address, alias?: NamespaceId[]): boolean;
 
     /**
      * @internal

--- a/src/model/transaction/TransferTransaction.ts
+++ b/src/model/transaction/TransferTransaction.ts
@@ -323,7 +323,7 @@ export class TransferTransaction extends Transaction {
      * @param alias address alias (names)
      * @returns {boolean}
      */
-    public shouldNotifiAccount(address: Address, alias: NamespaceId[]): boolean {
+    public shouldNotifyAccount(address: Address, alias: NamespaceId[]): boolean {
         return (
             super.isSigned(address) ||
             (this.recipientAddress as Address).equals(address) ||

--- a/src/model/transaction/TransferTransaction.ts
+++ b/src/model/transaction/TransferTransaction.ts
@@ -298,4 +298,19 @@ export class TransferTransaction extends Transaction {
             ),
         });
     }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @param alias address alias (names)
+     * @returns {boolean}
+     */
+    public NotifyAccount(address: Address, alias: NamespaceId[]): boolean {
+        return (
+            (this.signer !== undefined && this.signer!.address.equals(address)) ||
+            (this.recipientAddress as Address).equals(address) ||
+            alias.find((name) => (this.recipientAddress as NamespaceId).equals(name)) !== undefined
+        );
+    }
 }

--- a/src/model/transaction/TransferTransaction.ts
+++ b/src/model/transaction/TransferTransaction.ts
@@ -323,9 +323,9 @@ export class TransferTransaction extends Transaction {
      * @param alias address alias (names)
      * @returns {boolean}
      */
-    public NotifyAccount(address: Address, alias: NamespaceId[]): boolean {
+    public shouldNotifiAccount(address: Address, alias: NamespaceId[]): boolean {
         return (
-            (this.signer !== undefined && this.signer!.address.equals(address)) ||
+            super.isSigned(address) ||
             (this.recipientAddress as Address).equals(address) ||
             alias.find((name) => (this.recipientAddress as NamespaceId).equals(name)) !== undefined
         );

--- a/src/model/transaction/VotingKeyLinkTransaction.ts
+++ b/src/model/transaction/VotingKeyLinkTransaction.ts
@@ -192,10 +192,7 @@ export class VotingKeyLinkTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public NotifyAccount(address: Address): boolean {
-        return (
-            (this.signer !== undefined && this.signer!.address.equals(address)) ||
-            Address.createFromPublicKey(this.linkedPublicKey, this.networkType).equals(address)
-        );
+    public shouldNotifiAccount(address: Address): boolean {
+        return super.isSigned(address) || Address.createFromPublicKey(this.linkedPublicKey, this.networkType).equals(address);
     }
 }

--- a/src/model/transaction/VotingKeyLinkTransaction.ts
+++ b/src/model/transaction/VotingKeyLinkTransaction.ts
@@ -35,6 +35,7 @@ import { Transaction } from './Transaction';
 import { TransactionInfo } from './TransactionInfo';
 import { TransactionType } from './TransactionType';
 import { TransactionVersion } from './TransactionVersion';
+import { Address } from '../account/Address';
 
 export class VotingKeyLinkTransaction extends Transaction {
     /**
@@ -167,5 +168,18 @@ export class VotingKeyLinkTransaction extends Transaction {
      */
     resolveAliases(): VotingKeyLinkTransaction {
         return this;
+    }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @returns {boolean}
+     */
+    public NotifyAccount(address: Address): boolean {
+        return (
+            (this.signer !== undefined && this.signer!.address.equals(address)) ||
+            Address.createFromPublicKey(this.linkedPublicKey, this.networkType).equals(address)
+        );
     }
 }

--- a/src/model/transaction/VotingKeyLinkTransaction.ts
+++ b/src/model/transaction/VotingKeyLinkTransaction.ts
@@ -192,7 +192,7 @@ export class VotingKeyLinkTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public shouldNotifiAccount(address: Address): boolean {
+    public shouldNotifyAccount(address: Address): boolean {
         return super.isSigned(address) || Address.createFromPublicKey(this.linkedPublicKey, this.networkType).equals(address);
     }
 }

--- a/src/model/transaction/VrfKeyLinkTransaction.ts
+++ b/src/model/transaction/VrfKeyLinkTransaction.ts
@@ -34,6 +34,7 @@ import { Transaction } from './Transaction';
 import { TransactionInfo } from './TransactionInfo';
 import { TransactionType } from './TransactionType';
 import { TransactionVersion } from './TransactionVersion';
+import { Address } from '../account/Address';
 
 export class VrfKeyLinkTransaction extends Transaction {
     /**
@@ -166,5 +167,18 @@ export class VrfKeyLinkTransaction extends Transaction {
      */
     resolveAliases(): VrfKeyLinkTransaction {
         return this;
+    }
+
+    /**
+     * @internal
+     * Check a given address should be notified in websocket channels
+     * @param address address to be notified
+     * @returns {boolean}
+     */
+    public NotifyAccount(address: Address): boolean {
+        return (
+            (this.signer !== undefined && this.signer!.address.equals(address)) ||
+            Address.createFromPublicKey(this.linkedPublicKey, this.networkType).equals(address)
+        );
     }
 }

--- a/src/model/transaction/VrfKeyLinkTransaction.ts
+++ b/src/model/transaction/VrfKeyLinkTransaction.ts
@@ -191,10 +191,7 @@ export class VrfKeyLinkTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public NotifyAccount(address: Address): boolean {
-        return (
-            (this.signer !== undefined && this.signer!.address.equals(address)) ||
-            Address.createFromPublicKey(this.linkedPublicKey, this.networkType).equals(address)
-        );
+    public shouldNotifiAccount(address: Address): boolean {
+        return super.isSigned(address) || Address.createFromPublicKey(this.linkedPublicKey, this.networkType).equals(address);
     }
 }

--- a/src/model/transaction/VrfKeyLinkTransaction.ts
+++ b/src/model/transaction/VrfKeyLinkTransaction.ts
@@ -191,7 +191,7 @@ export class VrfKeyLinkTransaction extends Transaction {
      * @param address address to be notified
      * @returns {boolean}
      */
-    public shouldNotifiAccount(address: Address): boolean {
+    public shouldNotifyAccount(address: Address): boolean {
         return super.isSigned(address) || Address.createFromPublicKey(this.linkedPublicKey, this.networkType).equals(address);
     }
 }

--- a/src/service/AggregateTransactionService.ts
+++ b/src/service/AggregateTransactionService.ts
@@ -37,7 +37,7 @@ export class AggregateTransactionService {
     private readonly networkRepository: NetworkRepository;
     /**
      * Constructor
-     * @param multisigRepository
+     * @param repositoryFactory
      */
     constructor(repositoryFactory: RepositoryFactory) {
         this.multisigRepository = repositoryFactory.createMultisigRepository();

--- a/src/service/TransactionService.ts
+++ b/src/service/TransactionService.ts
@@ -15,7 +15,7 @@
  */
 
 import { merge, Observable, of } from 'rxjs';
-import { filter, first, flatMap, map, mergeMap, toArray } from 'rxjs/operators';
+import { first, flatMap, map, mergeMap, toArray } from 'rxjs/operators';
 import { IListener } from '../infrastructure/IListener';
 import { ReceiptRepository } from '../infrastructure/ReceiptRepository';
 import { TransactionRepository } from '../infrastructure/TransactionRepository';
@@ -129,7 +129,7 @@ export class TransactionService implements ITransactionService {
         transactionHash: string,
         transactionObservable: Observable<T>,
     ): Observable<T> {
-        const errorObservable = listener.status(address).pipe(filter((t) => t.hash.toUpperCase() === transactionHash.toUpperCase()));
+        const errorObservable = listener.status(address, transactionHash);
         return merge(transactionObservable, errorObservable).pipe(
             first(),
             map((errorOrTransaction) => {

--- a/test/infrastructure/Listener.spec.ts
+++ b/test/infrastructure/Listener.spec.ts
@@ -16,29 +16,28 @@
 
 import { deepEqual } from 'assert';
 import { expect } from 'chai';
-import { Listener } from '../../src/infrastructure/Listener';
-import { Address } from '../../src/model/account/Address';
-import { TransactionStatusError } from '../../src/model/transaction/TransactionStatusError';
-import { UInt64 } from '../../src/model/UInt64';
-import { instance, mock, when } from 'ts-mockito';
-import { of as observableOf } from 'rxjs';
-import { NetworkType } from '../../src/model/network/NetworkType';
+import { Observable, of as observableOf } from 'rxjs';
+import { deepEqual as deepEqualParam, instance, mock, verify, when } from 'ts-mockito';
+import { Listener, ListenerChannelName } from '../../src/infrastructure/Listener';
 import { NamespaceRepository } from '../../src/infrastructure/NamespaceRepository';
 import { Account } from '../../src/model/account/Account';
 import { AccountNames } from '../../src/model/account/AccountNames';
-import { NamespaceName, NamespaceId } from '../../src/model/model';
+import { Address } from '../../src/model/account/Address';
+import { Deadline, NamespaceId, NamespaceName, PlainMessage, Transaction, TransferTransaction } from '../../src/model/model';
+import { NetworkType } from '../../src/model/network/NetworkType';
+import { TransactionStatusError } from '../../src/model/transaction/TransactionStatusError';
+import { UInt64 } from '../../src/model/UInt64';
 
 describe('Listener', () => {
     const account = Account.createFromPrivateKey(
         '26b64cb10f005e5988a36744ca19e20d835ccc7c105aaa5f3b212da593180930',
         NetworkType.MIJIN_TEST,
     );
+
+    let namespaceRepoMock: NamespaceRepository;
     let namespaceRepo: NamespaceRepository;
-    before(() => {
-        const namespaceRepoMock: NamespaceRepository = mock();
-        when(namespaceRepoMock.getAccountsNames([account.address])).thenReturn(
-            observableOf([new AccountNames(account.address, [new NamespaceName(new NamespaceId('test'), 'test')])]),
-        );
+    beforeEach(() => {
+        namespaceRepoMock = mock();
         namespaceRepo = instance(namespaceRepoMock);
     });
 
@@ -81,6 +80,48 @@ describe('Listener', () => {
 
             listener.open();
 
+            const reportedStatus: TransactionStatusError[] = [];
+
+            listener.status(errorAddress).subscribe((error) => {
+                reportedStatus.push(error);
+            });
+
+            listener.handleMessage(statusInfoErrorDTO, null);
+
+            expect(reportedStatus.length).to.be.equal(1);
+            const transactionStatusError = reportedStatus[0];
+            expect(transactionStatusError.address).to.deep.equal(errorAddress);
+            expect(transactionStatusError.hash).to.be.equal(statusInfoErrorDTO.hash);
+            expect(transactionStatusError.code).to.be.equal(statusInfoErrorDTO.code);
+            deepEqual(transactionStatusError.deadline.toDTO(), UInt64.fromNumericString(statusInfoErrorDTO.deadline).toDTO());
+        });
+    });
+
+    describe('onConfirmed', () => {
+        it('Should forward status', () => {
+            const errorEncodedAddress = '906415867F121D037AF447E711B0F5E4D52EBBF066D96860EB';
+
+            const errorAddress = Address.createFromEncoded(errorEncodedAddress);
+
+            class WebSocketMock {
+                constructor(public readonly url: string) {}
+
+                send(payload: string): void {
+                    expect(payload).to.be.eq(`{"subscribe":"status/${errorAddress.plain()}"}`);
+                }
+            }
+
+            const statusInfoErrorDTO = {
+                address: errorEncodedAddress,
+                deadline: '1010',
+                hash: 'transaction-hash',
+                code: 'error-message',
+            };
+
+            const listener = new Listener('http://localhost:3000', namespaceRepo, WebSocketMock);
+
+            listener.open();
+
             const reportedStatus = new Array<TransactionStatusError>();
 
             listener.status(errorAddress).subscribe((error) => {
@@ -98,43 +139,6 @@ describe('Listener', () => {
         });
     });
 
-    describe('onStatusWhenAddressIsDifferentAddress', () => {
-        it('Should not forward status', () => {
-            const errorEncodedAddress = '906415867F121D037AF447E711B0F5E4D52EBBF066D96860EB';
-
-            const subscribedEncodedAddress = '906415867F121D037AF447E711B0F5E4D52EBBF066D96AAAAA';
-            const subscribedAddress = Address.createFromEncoded(subscribedEncodedAddress);
-
-            class WebSocketMock {
-                constructor(public readonly url: string) {}
-                send(payload: string): void {
-                    expect(payload).to.be.eq(`{"subscribe":"status/${subscribedAddress.plain()}"}`);
-                }
-            }
-
-            const statusInfoErrorDTO = {
-                address: errorEncodedAddress,
-                deadline: '1010',
-                hash: 'transaction-hash',
-                status: 'error-message',
-            };
-
-            const listener = new Listener('http://localhost:3000', namespaceRepo, WebSocketMock);
-
-            listener.open();
-
-            const reportedStatus = new Array<TransactionStatusError>();
-
-            listener.status(subscribedAddress).subscribe((transactionStatusError) => {
-                reportedStatus.push(transactionStatusError);
-            });
-
-            listener.handleMessage(statusInfoErrorDTO, null);
-
-            expect(reportedStatus.length).to.be.equal(0);
-        });
-    });
-
     describe('onerror', () => {
         it('should reject because of wrong server url', async () => {
             const listener = new Listener('https://notcorrecturl:0000', namespaceRepo);
@@ -146,6 +150,274 @@ describe('Listener', () => {
                 .catch((error) => {
                     expect(error.message.toString()).not.to.be.equal('');
                 });
+        });
+    });
+
+    [ListenerChannelName.confirmedAdded, ListenerChannelName.partialAdded, ListenerChannelName.unconfirmedAdded].forEach((name) => {
+        const subscribedAddress = account.address;
+        class WebSocketMock {
+            constructor(public readonly url: string) {}
+            send(payload: string): void {
+                expect(payload).to.be.eq(`{"subscribe":"${name}/${subscribedAddress.plain()}"}`);
+            }
+        }
+
+        const subscriptionMethod = (listener: Listener, address: Address, hash?: string): Observable<Transaction> => {
+            switch (name) {
+                case ListenerChannelName.confirmedAdded: {
+                    return listener.confirmed(address, hash);
+                }
+                case ListenerChannelName.unconfirmedAdded: {
+                    return listener.unconfirmedAdded(address, hash);
+                }
+                default: {
+                    return listener.aggregateBondedAdded(address, hash);
+                }
+            }
+        };
+
+        describe(`${name} transaction subscription`, () => {
+            it('Using alias', () => {
+                const alias = new NamespaceId('test');
+                when(namespaceRepoMock.getAccountsNames(deepEqualParam([subscribedAddress]))).thenReturn(
+                    observableOf([new AccountNames(subscribedAddress, [new NamespaceName(alias, 'test')])]),
+                );
+
+                const transferTransaction = TransferTransaction.create(
+                    Deadline.create(),
+                    alias,
+                    [],
+                    PlainMessage.create('test-message'),
+                    NetworkType.MIJIN_TEST,
+                );
+                const transferTransactionDTO = transferTransaction.toJSON();
+                const hash = 'abc';
+                transferTransactionDTO.meta = { channelName: name, height: '1', hash: hash };
+
+                const reportedTransactions: Transaction[] = [];
+                const listener = new Listener('http://localhost:3000', namespaceRepo, WebSocketMock);
+                listener.open();
+                subscriptionMethod(listener, subscribedAddress, hash).subscribe((confirmedTransaction) => {
+                    reportedTransactions.push(confirmedTransaction);
+                });
+
+                listener.handleMessage(transferTransactionDTO, null);
+                listener.handleMessage(transferTransactionDTO, null);
+
+                verify(namespaceRepoMock.getAccountsNames(deepEqualParam([subscribedAddress]))).times(2);
+                expect(reportedTransactions.length).to.be.equal(2);
+            });
+
+            it('Using invalid hash', () => {
+                const subscribedAddress = account.address;
+
+                const alias = new NamespaceId('test');
+                when(namespaceRepoMock.getAccountsNames(deepEqualParam([account.address]))).thenReturn(
+                    observableOf([new AccountNames(account.address, [new NamespaceName(alias, 'test')])]),
+                );
+                const transferTransaction = TransferTransaction.create(
+                    Deadline.create(),
+                    alias,
+                    [],
+                    PlainMessage.create('test-message'),
+                    NetworkType.MIJIN_TEST,
+                );
+                const transferTransactionDTO = transferTransaction.toJSON();
+                const hash = 'abc';
+                const hash2 = 'abc2';
+                transferTransactionDTO.meta = { channelName: name, height: '1', hash: hash };
+
+                const reportedTransactions: Transaction[] = [];
+                const listener = new Listener('http://localhost:3000', namespaceRepo, WebSocketMock);
+                listener.open();
+                subscriptionMethod(listener, subscribedAddress, hash2).subscribe((confirmedTransaction) => {
+                    reportedTransactions.push(confirmedTransaction);
+                });
+
+                listener.handleMessage(transferTransactionDTO, null);
+                listener.handleMessage(transferTransactionDTO, null);
+
+                expect(reportedTransactions.length).to.be.equal(0);
+                verify(namespaceRepoMock.getAccountsNames(deepEqualParam([account.address]))).times(0);
+            });
+
+            it('Using invalid no hash', () => {
+                const subscribedAddress = account.address;
+
+                const alias = new NamespaceId('test');
+                when(namespaceRepoMock.getAccountsNames(deepEqualParam([account.address]))).thenReturn(
+                    observableOf([new AccountNames(account.address, [new NamespaceName(alias, 'test')])]),
+                );
+                const transferTransaction = TransferTransaction.create(
+                    Deadline.create(),
+                    alias,
+                    [],
+                    PlainMessage.create('test-message'),
+                    NetworkType.MIJIN_TEST,
+                );
+                const transferTransactionDTO = transferTransaction.toJSON();
+                const hash = 'abc';
+                transferTransactionDTO.meta = { channelName: name, height: '1', hash: hash };
+
+                const reportedTransactions: Transaction[] = [];
+                const listener = new Listener('http://localhost:3000', namespaceRepo, WebSocketMock);
+                listener.open();
+                subscriptionMethod(listener, subscribedAddress).subscribe((confirmedTransaction) => {
+                    reportedTransactions.push(confirmedTransaction);
+                });
+
+                listener.handleMessage(transferTransactionDTO, null);
+                listener.handleMessage(transferTransactionDTO, null);
+
+                expect(reportedTransactions.length).to.be.equal(2);
+                verify(namespaceRepoMock.getAccountsNames(deepEqualParam([account.address]))).times(2);
+            });
+
+            it('Using alias invalid', () => {
+                const subscribedAddress = account.address;
+
+                const alias = new NamespaceId('test');
+                const alias2 = new NamespaceId('test2');
+                when(namespaceRepoMock.getAccountsNames(deepEqualParam([account.address]))).thenReturn(
+                    observableOf([new AccountNames(account.address, [new NamespaceName(alias, 'test')])]),
+                );
+                const transferTransaction = TransferTransaction.create(
+                    Deadline.create(),
+                    alias2,
+                    [],
+                    PlainMessage.create('test-message'),
+                    NetworkType.MIJIN_TEST,
+                );
+                const transferTransactionDTO = transferTransaction.toJSON();
+                const hash = 'abc';
+                transferTransactionDTO.meta = { channelName: name, height: '1', hash: hash };
+
+                const reportedTransactions: Transaction[] = [];
+
+                const listener = new Listener('http://localhost:3000', namespaceRepo, WebSocketMock);
+                listener.open();
+                subscriptionMethod(listener, subscribedAddress, hash).subscribe((unconfirmedTransaction) => {
+                    reportedTransactions.push(unconfirmedTransaction);
+                });
+
+                listener.handleMessage(transferTransactionDTO, null);
+                listener.handleMessage(transferTransactionDTO, null);
+
+                expect(reportedTransactions.length).to.be.equal(0);
+                verify(namespaceRepoMock.getAccountsNames(deepEqualParam([account.address]))).times(2);
+            });
+
+            it('Using signer', () => {
+                const subscribedAddress = account.address;
+
+                const alias = new NamespaceId('test');
+                const alias2 = new NamespaceId('test2');
+                when(namespaceRepoMock.getAccountsNames(deepEqualParam([account.address]))).thenReturn(
+                    observableOf([new AccountNames(account.address, [new NamespaceName(alias, 'test')])]),
+                );
+                const transferTransaction = TransferTransaction.create(
+                    Deadline.create(),
+                    alias2,
+                    [],
+                    PlainMessage.create('test-message'),
+                    NetworkType.MIJIN_TEST,
+                    undefined,
+                    undefined,
+                    account.publicAccount,
+                );
+                const transferTransactionDTO = transferTransaction.toJSON();
+                const hash = 'abc';
+                transferTransactionDTO.meta = { channelName: name, height: '1', hash: hash };
+
+                const reportedTransactions: Transaction[] = [];
+
+                const listener = new Listener('http://localhost:3000', namespaceRepo, WebSocketMock);
+                listener.open();
+                subscriptionMethod(listener, subscribedAddress, hash).subscribe((confirmedTransaction) => {
+                    reportedTransactions.push(confirmedTransaction);
+                });
+
+                listener.handleMessage(transferTransactionDTO, null);
+                listener.handleMessage(transferTransactionDTO, null);
+
+                expect(reportedTransactions.length).to.be.equal(2);
+                //There is no need for the extra call, it finish when the signer is finer
+                verify(namespaceRepoMock.getAccountsNames(deepEqualParam([account.address]))).times(0);
+            });
+        });
+    });
+
+    [ListenerChannelName.unconfirmedRemoved, ListenerChannelName.partialRemoved].forEach((name) => {
+        const subscribedAddress = account.address;
+        class WebSocketMock {
+            constructor(public readonly url: string) {}
+            send(payload: string): void {
+                expect(payload).to.be.eq(`{"subscribe":"${name}/${subscribedAddress.plain()}"}`);
+            }
+        }
+
+        const subscriptionMethod = (listener: Listener, address: Address, hash?: string): Observable<string> => {
+            switch (name) {
+                case ListenerChannelName.unconfirmedRemoved: {
+                    return listener.unconfirmedRemoved(address, hash);
+                }
+                default: {
+                    return listener.aggregateBondedRemoved(address, hash);
+                }
+            }
+        };
+
+        describe(`${name} transaction hash subscription`, () => {
+            it('Using valid hash', () => {
+                const hash = 'abc';
+                const message = { meta: { channelName: name, height: '1', hash: hash } };
+
+                const reportedTransactions: string[] = [];
+                const listener = new Listener('http://localhost:3000', namespaceRepo, WebSocketMock);
+                listener.open();
+                subscriptionMethod(listener, subscribedAddress, hash).subscribe((confirmedHash) => {
+                    reportedTransactions.push(confirmedHash);
+                });
+
+                listener.handleMessage(message, null);
+                listener.handleMessage(message, null);
+
+                expect(reportedTransactions.length).to.be.equal(2);
+            });
+
+            it('Using valid no hash', () => {
+                const hash = 'abc';
+                const message = { meta: { channelName: name, height: '1', hash: hash } };
+
+                const reportedTransactions: string[] = [];
+                const listener = new Listener('http://localhost:3000', namespaceRepo, WebSocketMock);
+                listener.open();
+                subscriptionMethod(listener, subscribedAddress).subscribe((confirmedHash) => {
+                    reportedTransactions.push(confirmedHash);
+                });
+
+                listener.handleMessage(message, null);
+                listener.handleMessage(message, null);
+
+                expect(reportedTransactions.length).to.be.equal(2);
+            });
+
+            it('Using invalid hash', () => {
+                const hash = 'abc';
+                const message = { meta: { channelName: name, height: '1', hash: hash } };
+
+                const reportedTransactions: string[] = [];
+                const listener = new Listener('http://localhost:3000', namespaceRepo, WebSocketMock);
+                listener.open();
+                subscriptionMethod(listener, subscribedAddress, 'invalid!').subscribe((confirmedHash) => {
+                    reportedTransactions.push(confirmedHash);
+                });
+
+                listener.handleMessage(message, null);
+                listener.handleMessage(message, null);
+
+                expect(reportedTransactions.length).to.be.equal(0);
+            });
         });
     });
 });

--- a/test/model/transaction/AccountKeyLinkTransaction.spec.ts
+++ b/test/model/transaction/AccountKeyLinkTransaction.spec.ts
@@ -121,13 +121,13 @@ describe('AccountKeyLinkTransaction', () => {
 
     it('Notify Account', () => {
         const tx = AccountKeyLinkTransaction.create(Deadline.create(), account.publicKey, LinkAction.Unlink, NetworkType.MIJIN_TEST);
-        let canNotify = tx.NotifyAccount(account.address);
+        let canNotify = tx.shouldNotifiAccount(account.address);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.NotifyAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/AccountKeyLinkTransaction.spec.ts
+++ b/test/model/transaction/AccountKeyLinkTransaction.spec.ts
@@ -23,6 +23,7 @@ import { Deadline } from '../../../src/model/transaction/Deadline';
 import { LinkAction } from '../../../src/model/transaction/LinkAction';
 import { UInt64 } from '../../../src/model/UInt64';
 import { TestingAccount } from '../../conf/conf.spec';
+import { Address } from '../../../src/model/account/Address';
 
 describe('AccountKeyLinkTransaction', () => {
     let account: Account;
@@ -116,5 +117,17 @@ describe('AccountKeyLinkTransaction', () => {
 
         const signedTransaction = accountKeyLinkTransaction.signWith(account, generationHash);
         expect(signedTransaction.hash).not.to.be.undefined;
+    });
+
+    it('Notify Account', () => {
+        const tx = AccountKeyLinkTransaction.create(Deadline.create(), account.publicKey, LinkAction.Unlink, NetworkType.MIJIN_TEST);
+        let canNotify = tx.NotifyAccount(account.address);
+        expect(canNotify).to.be.true;
+
+        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        expect(canNotify).to.be.false;
+
+        Object.assign(tx, { signer: account.publicAccount });
+        expect(tx.NotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/AccountKeyLinkTransaction.spec.ts
+++ b/test/model/transaction/AccountKeyLinkTransaction.spec.ts
@@ -121,13 +121,13 @@ describe('AccountKeyLinkTransaction', () => {
 
     it('Notify Account', () => {
         const tx = AccountKeyLinkTransaction.create(Deadline.create(), account.publicKey, LinkAction.Unlink, NetworkType.MIJIN_TEST);
-        let canNotify = tx.shouldNotifiAccount(account.address);
+        let canNotify = tx.shouldNotifyAccount(account.address);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        canNotify = tx.shouldNotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/AccountMetadataTransaction.spec.ts
+++ b/test/model/transaction/AccountMetadataTransaction.spec.ts
@@ -144,13 +144,13 @@ describe('AccountMetadataTransaction', () => {
             NetworkType.MIJIN_TEST,
         );
 
-        let canNotify = tx.shouldNotifiAccount(account.address);
+        let canNotify = tx.shouldNotifyAccount(account.address);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        canNotify = tx.shouldNotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/AccountMetadataTransaction.spec.ts
+++ b/test/model/transaction/AccountMetadataTransaction.spec.ts
@@ -144,13 +144,13 @@ describe('AccountMetadataTransaction', () => {
             NetworkType.MIJIN_TEST,
         );
 
-        let canNotify = tx.NotifyAccount(account.address);
+        let canNotify = tx.shouldNotifiAccount(account.address);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.NotifyAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/AccountMetadataTransaction.spec.ts
+++ b/test/model/transaction/AccountMetadataTransaction.spec.ts
@@ -25,6 +25,7 @@ import { TestingAccount } from '../../conf/conf.spec';
 import { EmbeddedTransactionBuilder } from 'catbuffer-typescript/dist/EmbeddedTransactionBuilder';
 import { TransactionType } from '../../../src/model/transaction/TransactionType';
 import { deepEqual } from 'assert';
+import { Address } from '../../../src/model/account/Address';
 
 describe('AccountMetadataTransaction', () => {
     let account: Account;
@@ -131,5 +132,25 @@ describe('AccountMetadataTransaction', () => {
 
         expect(resolved).to.be.instanceOf(AccountMetadataTransaction);
         deepEqual(accountMetadataTransaction, resolved);
+    });
+
+    it('Notify Account', () => {
+        const tx = AccountMetadataTransaction.create(
+            Deadline.create(),
+            account.publicKey,
+            UInt64.fromUint(1000),
+            1,
+            Convert.uint8ToUtf8(new Uint8Array(10)),
+            NetworkType.MIJIN_TEST,
+        );
+
+        let canNotify = tx.NotifyAccount(account.address);
+        expect(canNotify).to.be.true;
+
+        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        expect(canNotify).to.be.false;
+
+        Object.assign(tx, { signer: account.publicAccount });
+        expect(tx.NotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/AccountRestrictionTransaction.spec.ts
+++ b/test/model/transaction/AccountRestrictionTransaction.spec.ts
@@ -311,14 +311,14 @@ describe('AccountRestrictionTransaction', () => {
             [],
             NetworkType.MIJIN_TEST,
         );
-        let canNotify = tx.NotifyAccount(address, []);
+        let canNotify = tx.shouldNotifiAccount(address, []);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.NotifyAccount(account.address, [])).to.be.true;
+        expect(tx.shouldNotifiAccount(account.address, [])).to.be.true;
 
         const txDeletion = AccountRestrictionTransaction.createAddressRestrictionModificationTransaction(
             Deadline.create(),
@@ -327,14 +327,14 @@ describe('AccountRestrictionTransaction', () => {
             [address],
             NetworkType.MIJIN_TEST,
         );
-        let canNotifyDeletion = txDeletion.NotifyAccount(address, []);
+        let canNotifyDeletion = txDeletion.shouldNotifiAccount(address, []);
         expect(canNotifyDeletion).to.be.true;
 
-        canNotifyDeletion = txDeletion.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        canNotifyDeletion = txDeletion.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
         expect(canNotifyDeletion).to.be.false;
 
         Object.assign(txDeletion, { signer: account.publicAccount });
-        expect(txDeletion.NotifyAccount(account.address, [])).to.be.true;
+        expect(txDeletion.shouldNotifiAccount(account.address, [])).to.be.true;
     });
 
     it('Notify Account with alias', () => {
@@ -346,14 +346,14 @@ describe('AccountRestrictionTransaction', () => {
             [],
             NetworkType.MIJIN_TEST,
         );
-        let canNotify = tx.NotifyAccount(account.address, [address]);
+        let canNotify = tx.shouldNotifiAccount(account.address, [address]);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.NotifyAccount(account.address, [])).to.be.true;
+        expect(tx.shouldNotifiAccount(account.address, [])).to.be.true;
 
         const txDeletion = AccountRestrictionTransaction.createAddressRestrictionModificationTransaction(
             Deadline.create(),
@@ -362,13 +362,13 @@ describe('AccountRestrictionTransaction', () => {
             [address],
             NetworkType.MIJIN_TEST,
         );
-        let canNotifyDeletion = txDeletion.NotifyAccount(account.address, [address]);
+        let canNotifyDeletion = txDeletion.shouldNotifiAccount(account.address, [address]);
         expect(canNotifyDeletion).to.be.true;
 
-        canNotifyDeletion = txDeletion.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        canNotifyDeletion = txDeletion.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
         expect(canNotifyDeletion).to.be.false;
 
         Object.assign(txDeletion, { signer: account.publicAccount });
-        expect(txDeletion.NotifyAccount(account.address, [])).to.be.true;
+        expect(txDeletion.shouldNotifiAccount(account.address, [])).to.be.true;
     });
 });

--- a/test/model/transaction/AccountRestrictionTransaction.spec.ts
+++ b/test/model/transaction/AccountRestrictionTransaction.spec.ts
@@ -28,6 +28,7 @@ import { Deadline } from '../../../src/model/transaction/Deadline';
 import { TransactionType } from '../../../src/model/transaction/TransactionType';
 import { UInt64 } from '../../../src/model/UInt64';
 import { TestingAccount } from '../../conf/conf.spec';
+import { NamespaceId } from '../../../src/model/namespace/NamespaceId';
 
 describe('AccountRestrictionTransaction', () => {
     let account: Account;
@@ -299,5 +300,75 @@ describe('AccountRestrictionTransaction', () => {
         signedTransaction = operationRestrictionTransaction.signWith(account, generationHash);
 
         expect(signedTransaction.payload.substring(256, signedTransaction.payload.length)).to.be.equal('04C00100000000004E42');
+    });
+
+    it('Notify Account', () => {
+        const address = Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
+        const tx = AccountRestrictionTransaction.createAddressRestrictionModificationTransaction(
+            Deadline.create(),
+            AccountRestrictionFlags.AllowOutgoingAddress,
+            [address],
+            [],
+            NetworkType.MIJIN_TEST,
+        );
+        let canNotify = tx.NotifyAccount(address, []);
+        expect(canNotify).to.be.true;
+
+        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        expect(canNotify).to.be.false;
+
+        Object.assign(tx, { signer: account.publicAccount });
+        expect(tx.NotifyAccount(account.address, [])).to.be.true;
+
+        const txDeletion = AccountRestrictionTransaction.createAddressRestrictionModificationTransaction(
+            Deadline.create(),
+            AccountRestrictionFlags.AllowOutgoingAddress,
+            [],
+            [address],
+            NetworkType.MIJIN_TEST,
+        );
+        let canNotifyDeletion = txDeletion.NotifyAccount(address, []);
+        expect(canNotifyDeletion).to.be.true;
+
+        canNotifyDeletion = txDeletion.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        expect(canNotifyDeletion).to.be.false;
+
+        Object.assign(txDeletion, { signer: account.publicAccount });
+        expect(txDeletion.NotifyAccount(account.address, [])).to.be.true;
+    });
+
+    it('Notify Account with alias', () => {
+        const address = new NamespaceId('test');
+        const tx = AccountRestrictionTransaction.createAddressRestrictionModificationTransaction(
+            Deadline.create(),
+            AccountRestrictionFlags.AllowOutgoingAddress,
+            [address],
+            [],
+            NetworkType.MIJIN_TEST,
+        );
+        let canNotify = tx.NotifyAccount(account.address, [address]);
+        expect(canNotify).to.be.true;
+
+        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        expect(canNotify).to.be.false;
+
+        Object.assign(tx, { signer: account.publicAccount });
+        expect(tx.NotifyAccount(account.address, [])).to.be.true;
+
+        const txDeletion = AccountRestrictionTransaction.createAddressRestrictionModificationTransaction(
+            Deadline.create(),
+            AccountRestrictionFlags.AllowOutgoingAddress,
+            [],
+            [address],
+            NetworkType.MIJIN_TEST,
+        );
+        let canNotifyDeletion = txDeletion.NotifyAccount(account.address, [address]);
+        expect(canNotifyDeletion).to.be.true;
+
+        canNotifyDeletion = txDeletion.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        expect(canNotifyDeletion).to.be.false;
+
+        Object.assign(txDeletion, { signer: account.publicAccount });
+        expect(txDeletion.NotifyAccount(account.address, [])).to.be.true;
     });
 });

--- a/test/model/transaction/AccountRestrictionTransaction.spec.ts
+++ b/test/model/transaction/AccountRestrictionTransaction.spec.ts
@@ -311,14 +311,14 @@ describe('AccountRestrictionTransaction', () => {
             [],
             NetworkType.MIJIN_TEST,
         );
-        let canNotify = tx.shouldNotifiAccount(address, []);
+        let canNotify = tx.shouldNotifyAccount(address, []);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        canNotify = tx.shouldNotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.shouldNotifiAccount(account.address, [])).to.be.true;
+        expect(tx.shouldNotifyAccount(account.address, [])).to.be.true;
 
         const txDeletion = AccountRestrictionTransaction.createAddressRestrictionModificationTransaction(
             Deadline.create(),
@@ -327,14 +327,14 @@ describe('AccountRestrictionTransaction', () => {
             [address],
             NetworkType.MIJIN_TEST,
         );
-        let canNotifyDeletion = txDeletion.shouldNotifiAccount(address, []);
+        let canNotifyDeletion = txDeletion.shouldNotifyAccount(address, []);
         expect(canNotifyDeletion).to.be.true;
 
-        canNotifyDeletion = txDeletion.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        canNotifyDeletion = txDeletion.shouldNotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
         expect(canNotifyDeletion).to.be.false;
 
         Object.assign(txDeletion, { signer: account.publicAccount });
-        expect(txDeletion.shouldNotifiAccount(account.address, [])).to.be.true;
+        expect(txDeletion.shouldNotifyAccount(account.address, [])).to.be.true;
     });
 
     it('Notify Account with alias', () => {
@@ -346,14 +346,14 @@ describe('AccountRestrictionTransaction', () => {
             [],
             NetworkType.MIJIN_TEST,
         );
-        let canNotify = tx.shouldNotifiAccount(account.address, [address]);
+        let canNotify = tx.shouldNotifyAccount(account.address, [address]);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        canNotify = tx.shouldNotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.shouldNotifiAccount(account.address, [])).to.be.true;
+        expect(tx.shouldNotifyAccount(account.address, [])).to.be.true;
 
         const txDeletion = AccountRestrictionTransaction.createAddressRestrictionModificationTransaction(
             Deadline.create(),
@@ -362,13 +362,13 @@ describe('AccountRestrictionTransaction', () => {
             [address],
             NetworkType.MIJIN_TEST,
         );
-        let canNotifyDeletion = txDeletion.shouldNotifiAccount(account.address, [address]);
+        let canNotifyDeletion = txDeletion.shouldNotifyAccount(account.address, [address]);
         expect(canNotifyDeletion).to.be.true;
 
-        canNotifyDeletion = txDeletion.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        canNotifyDeletion = txDeletion.shouldNotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
         expect(canNotifyDeletion).to.be.false;
 
         Object.assign(txDeletion, { signer: account.publicAccount });
-        expect(txDeletion.shouldNotifiAccount(account.address, [])).to.be.true;
+        expect(txDeletion.shouldNotifyAccount(account.address, [])).to.be.true;
     });
 });

--- a/test/model/transaction/AddressAliasTransaction.spec.ts
+++ b/test/model/transaction/AddressAliasTransaction.spec.ts
@@ -115,4 +115,19 @@ describe('AddressAliasTransaction', () => {
         ).setMaxFee(2);
         expect(addressAliasTransaction.maxFee.compact()).to.be.equal(324);
     });
+
+    it('Notify Account', () => {
+        const namespaceId = new NamespaceId([33347626, 3779697293]);
+        const address = Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
+        const tx = AddressAliasTransaction.create(Deadline.create(), AliasAction.Link, namespaceId, address, NetworkType.MIJIN_TEST);
+
+        let canNotify = tx.NotifyAccount(address);
+        expect(canNotify).to.be.true;
+
+        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        expect(canNotify).to.be.false;
+
+        Object.assign(tx, { signer: account.publicAccount });
+        expect(tx.NotifyAccount(account.address)).to.be.true;
+    });
 });

--- a/test/model/transaction/AddressAliasTransaction.spec.ts
+++ b/test/model/transaction/AddressAliasTransaction.spec.ts
@@ -121,13 +121,13 @@ describe('AddressAliasTransaction', () => {
         const address = Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
         const tx = AddressAliasTransaction.create(Deadline.create(), AliasAction.Link, namespaceId, address, NetworkType.MIJIN_TEST);
 
-        let canNotify = tx.NotifyAccount(address);
+        let canNotify = tx.shouldNotifiAccount(address);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.NotifyAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/AddressAliasTransaction.spec.ts
+++ b/test/model/transaction/AddressAliasTransaction.spec.ts
@@ -121,13 +121,13 @@ describe('AddressAliasTransaction', () => {
         const address = Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
         const tx = AddressAliasTransaction.create(Deadline.create(), AliasAction.Link, namespaceId, address, NetworkType.MIJIN_TEST);
 
-        let canNotify = tx.shouldNotifiAccount(address);
+        let canNotify = tx.shouldNotifyAccount(address);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        canNotify = tx.shouldNotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/AggregateTransaction.spec.ts
+++ b/test/model/transaction/AggregateTransaction.spec.ts
@@ -683,14 +683,14 @@ describe('AggregateTransaction', () => {
             NetworkType.MIJIN_TEST,
             [],
         );
-        let canNotify = tx.NotifyAccount(account.address, []);
+        let canNotify = tx.shouldNotifiAccount(account.address, []);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.NotifyAccount(account.address, [])).to.be.true;
+        expect(tx.shouldNotifiAccount(account.address, [])).to.be.true;
     });
 
     it('Notify Account with alias', () => {
@@ -707,13 +707,15 @@ describe('AggregateTransaction', () => {
             NetworkType.MIJIN_TEST,
             [],
         );
-        let canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), [unresolvedAddress]);
+        let canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), [
+            unresolvedAddress,
+        ]);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.NotifyAccount(account.address, [])).to.be.true;
+        expect(tx.shouldNotifiAccount(account.address, [])).to.be.true;
     });
 });

--- a/test/model/transaction/AggregateTransaction.spec.ts
+++ b/test/model/transaction/AggregateTransaction.spec.ts
@@ -683,14 +683,14 @@ describe('AggregateTransaction', () => {
             NetworkType.MIJIN_TEST,
             [],
         );
-        let canNotify = tx.shouldNotifiAccount(account.address, []);
+        let canNotify = tx.shouldNotifyAccount(account.address, []);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        canNotify = tx.shouldNotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.shouldNotifiAccount(account.address, [])).to.be.true;
+        expect(tx.shouldNotifyAccount(account.address, [])).to.be.true;
     });
 
     it('Notify Account with alias', () => {
@@ -707,15 +707,15 @@ describe('AggregateTransaction', () => {
             NetworkType.MIJIN_TEST,
             [],
         );
-        let canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), [
+        let canNotify = tx.shouldNotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), [
             unresolvedAddress,
         ]);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        canNotify = tx.shouldNotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.shouldNotifiAccount(account.address, [])).to.be.true;
+        expect(tx.shouldNotifyAccount(account.address, [])).to.be.true;
     });
 });

--- a/test/model/transaction/AggregateTransaction.spec.ts
+++ b/test/model/transaction/AggregateTransaction.spec.ts
@@ -668,4 +668,52 @@ describe('AggregateTransaction', () => {
         const signedTransaction = aggregateTransaction.signWith(account, generationHash);
         expect(signedTransaction.hash).not.to.be.undefined;
     });
+
+    it('Notify Account', () => {
+        const transferTransaction = TransferTransaction.create(
+            Deadline.create(1, ChronoUnit.HOURS),
+            account.address,
+            [new Mosaic(unresolvedMosaicId, UInt64.fromUint(1))],
+            PlainMessage.create('test-message'),
+            NetworkType.MIJIN_TEST,
+        );
+        const tx = AggregateTransaction.createComplete(
+            Deadline.create(),
+            [transferTransaction.toAggregate(account.publicAccount)],
+            NetworkType.MIJIN_TEST,
+            [],
+        );
+        let canNotify = tx.NotifyAccount(account.address, []);
+        expect(canNotify).to.be.true;
+
+        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        expect(canNotify).to.be.false;
+
+        Object.assign(tx, { signer: account.publicAccount });
+        expect(tx.NotifyAccount(account.address, [])).to.be.true;
+    });
+
+    it('Notify Account with alias', () => {
+        const transferTransaction = TransferTransaction.create(
+            Deadline.create(1, ChronoUnit.HOURS),
+            unresolvedAddress,
+            [new Mosaic(unresolvedMosaicId, UInt64.fromUint(1))],
+            PlainMessage.create('test-message'),
+            NetworkType.MIJIN_TEST,
+        );
+        const tx = AggregateTransaction.createComplete(
+            Deadline.create(),
+            [transferTransaction.toAggregate(account.publicAccount)],
+            NetworkType.MIJIN_TEST,
+            [],
+        );
+        let canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), [unresolvedAddress]);
+        expect(canNotify).to.be.true;
+
+        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        expect(canNotify).to.be.false;
+
+        Object.assign(tx, { signer: account.publicAccount });
+        expect(tx.NotifyAccount(account.address, [])).to.be.true;
+    });
 });

--- a/test/model/transaction/HashLockTransaction.spec.ts
+++ b/test/model/transaction/HashLockTransaction.spec.ts
@@ -68,6 +68,6 @@ describe('HashLockTransaction', () => {
         );
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.NotifyAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/HashLockTransaction.spec.ts
+++ b/test/model/transaction/HashLockTransaction.spec.ts
@@ -68,6 +68,6 @@ describe('HashLockTransaction', () => {
         );
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/HashLockTransaction.spec.ts
+++ b/test/model/transaction/HashLockTransaction.spec.ts
@@ -55,4 +55,19 @@ describe('HashLockTransaction', () => {
             );
         }).to.throw(Error);
     });
+
+    it('Notify Account', () => {
+        const aggregateTransaction = AggregateTransaction.createBonded(Deadline.create(), [], NetworkType.MIJIN_TEST, []);
+        const signedTransaction = account.sign(aggregateTransaction, generationHash);
+        const tx = HashLockTransaction.create(
+            Deadline.create(),
+            NetworkCurrencyLocal.createRelative(10),
+            UInt64.fromUint(10),
+            signedTransaction,
+            NetworkType.MIJIN_TEST,
+        );
+
+        Object.assign(tx, { signer: account.publicAccount });
+        expect(tx.NotifyAccount(account.address)).to.be.true;
+    });
 });

--- a/test/model/transaction/LockFundsTransaction.spec.ts
+++ b/test/model/transaction/LockFundsTransaction.spec.ts
@@ -196,6 +196,6 @@ describe('LockFundsTransaction', () => {
         );
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.NotifyAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/LockFundsTransaction.spec.ts
+++ b/test/model/transaction/LockFundsTransaction.spec.ts
@@ -196,6 +196,6 @@ describe('LockFundsTransaction', () => {
         );
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/LockFundsTransaction.spec.ts
+++ b/test/model/transaction/LockFundsTransaction.spec.ts
@@ -183,4 +183,19 @@ describe('LockFundsTransaction', () => {
         const signedTransactionTest = transaction.signWith(account, generationHash);
         expect(signedTransactionTest.hash).not.to.be.undefined;
     });
+
+    it('Notify Account', () => {
+        const aggregateTransaction = AggregateTransaction.createBonded(Deadline.create(), [], NetworkType.MIJIN_TEST, []);
+        const signedTransaction = account.sign(aggregateTransaction, generationHash);
+        const tx = LockFundsTransaction.create(
+            Deadline.create(),
+            NetworkCurrencyLocal.createRelative(10),
+            UInt64.fromUint(10),
+            signedTransaction,
+            NetworkType.MIJIN_TEST,
+        );
+
+        Object.assign(tx, { signer: account.publicAccount });
+        expect(tx.NotifyAccount(account.address)).to.be.true;
+    });
 });

--- a/test/model/transaction/MosaicAliasTransaction.spec.ts
+++ b/test/model/transaction/MosaicAliasTransaction.spec.ts
@@ -163,6 +163,6 @@ describe('MosaicAliasTransaction', () => {
         const tx = MosaicAliasTransaction.create(Deadline.create(), AliasAction.Link, namespaceId, mosaicId, NetworkType.MIJIN_TEST);
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.NotifyAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/MosaicAliasTransaction.spec.ts
+++ b/test/model/transaction/MosaicAliasTransaction.spec.ts
@@ -163,6 +163,6 @@ describe('MosaicAliasTransaction', () => {
         const tx = MosaicAliasTransaction.create(Deadline.create(), AliasAction.Link, namespaceId, mosaicId, NetworkType.MIJIN_TEST);
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/MosaicAliasTransaction.spec.ts
+++ b/test/model/transaction/MosaicAliasTransaction.spec.ts
@@ -156,4 +156,13 @@ describe('MosaicAliasTransaction', () => {
         expect(Convert.uint8ToHex(embedded.signerPublicKey.key)).to.be.equal(account.publicKey);
         expect(embedded.type.valueOf()).to.be.equal(TransactionType.MOSAIC_ALIAS.valueOf());
     });
+
+    it('Notify Account', () => {
+        const namespaceId = new NamespaceId([33347626, 3779697293]);
+        const mosaicId = new MosaicId([2262289484, 3405110546]);
+        const tx = MosaicAliasTransaction.create(Deadline.create(), AliasAction.Link, namespaceId, mosaicId, NetworkType.MIJIN_TEST);
+
+        Object.assign(tx, { signer: account.publicAccount });
+        expect(tx.NotifyAccount(account.address)).to.be.true;
+    });
 });

--- a/test/model/transaction/MosaicDefinitionTransaction.spec.ts
+++ b/test/model/transaction/MosaicDefinitionTransaction.spec.ts
@@ -168,4 +168,19 @@ describe('MosaicDefinitionTransaction', () => {
         const signedTransaction = mosaicDefinitionTransaction.signWith(account, generationHash);
         expect(signedTransaction.hash).not.to.be.undefined;
     });
+
+    it('Notify Account', () => {
+        const tx = MosaicDefinitionTransaction.create(
+            Deadline.create(),
+            MosaicNonce.createFromUint8Array(new Uint8Array([0xe6, 0xde, 0x84, 0xb8])), // nonce
+            new MosaicId(UInt64.fromUint(1).toDTO()), // ID
+            MosaicFlags.create(false, false, false),
+            3,
+            UInt64.fromUint(0),
+            NetworkType.MIJIN_TEST,
+        );
+
+        Object.assign(tx, { signer: account.publicAccount });
+        expect(tx.NotifyAccount(account.address)).to.be.true;
+    });
 });

--- a/test/model/transaction/MosaicDefinitionTransaction.spec.ts
+++ b/test/model/transaction/MosaicDefinitionTransaction.spec.ts
@@ -181,6 +181,6 @@ describe('MosaicDefinitionTransaction', () => {
         );
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/MosaicDefinitionTransaction.spec.ts
+++ b/test/model/transaction/MosaicDefinitionTransaction.spec.ts
@@ -181,6 +181,6 @@ describe('MosaicDefinitionTransaction', () => {
         );
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.NotifyAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/MosaicGlobalRestrictionTransaction.spec.ts
+++ b/test/model/transaction/MosaicGlobalRestrictionTransaction.spec.ts
@@ -207,6 +207,6 @@ describe('MosaicGlobalRestrictionTransaction', () => {
         );
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/MosaicGlobalRestrictionTransaction.spec.ts
+++ b/test/model/transaction/MosaicGlobalRestrictionTransaction.spec.ts
@@ -190,4 +190,23 @@ describe('MosaicGlobalRestrictionTransaction', () => {
         const signedTransaction = mosaicGlobalRestrictionTransaction.signWith(account, generationHash);
         expect(signedTransaction.hash).not.to.be.undefined;
     });
+
+    it('Notify Account', () => {
+        const mosaicId = new MosaicId(UInt64.fromUint(1).toDTO());
+        const referenceMosaicId = new MosaicId(UInt64.fromUint(2).toDTO());
+        const tx = MosaicGlobalRestrictionTransaction.create(
+            Deadline.create(),
+            mosaicId,
+            UInt64.fromUint(1),
+            UInt64.fromUint(9),
+            MosaicRestrictionType.EQ,
+            UInt64.fromUint(8),
+            MosaicRestrictionType.GE,
+            NetworkType.MIJIN_TEST,
+            referenceMosaicId,
+        );
+
+        Object.assign(tx, { signer: account.publicAccount });
+        expect(tx.NotifyAccount(account.address)).to.be.true;
+    });
 });

--- a/test/model/transaction/MosaicGlobalRestrictionTransaction.spec.ts
+++ b/test/model/transaction/MosaicGlobalRestrictionTransaction.spec.ts
@@ -207,6 +207,6 @@ describe('MosaicGlobalRestrictionTransaction', () => {
         );
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.NotifyAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/MosaicMetadataTransaction.spec.ts
+++ b/test/model/transaction/MosaicMetadataTransaction.spec.ts
@@ -206,13 +206,13 @@ describe('MosaicMetadataTransaction', () => {
             Convert.uint8ToUtf8(new Uint8Array(10)),
             NetworkType.MIJIN_TEST,
         );
-        let canNotify = tx.NotifyAccount(account.address);
+        let canNotify = tx.shouldNotifiAccount(account.address);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.NotifyAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/MosaicMetadataTransaction.spec.ts
+++ b/test/model/transaction/MosaicMetadataTransaction.spec.ts
@@ -206,13 +206,13 @@ describe('MosaicMetadataTransaction', () => {
             Convert.uint8ToUtf8(new Uint8Array(10)),
             NetworkType.MIJIN_TEST,
         );
-        let canNotify = tx.shouldNotifiAccount(account.address);
+        let canNotify = tx.shouldNotifyAccount(account.address);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        canNotify = tx.shouldNotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/MosaicMetadataTransaction.spec.ts
+++ b/test/model/transaction/MosaicMetadataTransaction.spec.ts
@@ -31,7 +31,7 @@ import { TransactionInfo } from '../../../src/model/transaction/TransactionInfo'
 import { UInt64 } from '../../../src/model/UInt64';
 import { TestingAccount } from '../../conf/conf.spec';
 import { EmbeddedTransactionBuilder } from 'catbuffer-typescript';
-import { TransactionType } from '../../../src/model/model';
+import { TransactionType, Address } from '../../../src/model/model';
 
 describe('MosaicMetadataTransaction', () => {
     let account: Account;
@@ -194,5 +194,25 @@ describe('MosaicMetadataTransaction', () => {
         expect(embedded).to.be.instanceOf(EmbeddedTransactionBuilder);
         expect(Convert.uint8ToHex(embedded.signerPublicKey.key)).to.be.equal(account.publicKey);
         expect(embedded.type.valueOf()).to.be.equal(TransactionType.MOSAIC_METADATA.valueOf());
+    });
+
+    it('Notify Account', () => {
+        const tx = MosaicMetadataTransaction.create(
+            Deadline.create(),
+            account.publicKey,
+            UInt64.fromUint(1000),
+            new MosaicId([2262289484, 3405110546]),
+            1,
+            Convert.uint8ToUtf8(new Uint8Array(10)),
+            NetworkType.MIJIN_TEST,
+        );
+        let canNotify = tx.NotifyAccount(account.address);
+        expect(canNotify).to.be.true;
+
+        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        expect(canNotify).to.be.false;
+
+        Object.assign(tx, { signer: account.publicAccount });
+        expect(tx.NotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/MosaicSupplyChangeTransaction.spec.ts
+++ b/test/model/transaction/MosaicSupplyChangeTransaction.spec.ts
@@ -162,6 +162,6 @@ describe('MosaicSupplyChangeTransaction', () => {
         );
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.NotifyAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/MosaicSupplyChangeTransaction.spec.ts
+++ b/test/model/transaction/MosaicSupplyChangeTransaction.spec.ts
@@ -162,6 +162,6 @@ describe('MosaicSupplyChangeTransaction', () => {
         );
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/MosaicSupplyChangeTransaction.spec.ts
+++ b/test/model/transaction/MosaicSupplyChangeTransaction.spec.ts
@@ -151,4 +151,17 @@ describe('MosaicSupplyChangeTransaction', () => {
         const signedTransaction = mosaicSupplyChangeTransaction.signWith(account, generationHash);
         expect(signedTransaction.hash).not.to.be.undefined;
     });
+
+    it('Notify Account', () => {
+        const tx = MosaicSupplyChangeTransaction.create(
+            Deadline.create(),
+            new MosaicId([2262289484, 3405110546]),
+            MosaicSupplyChangeAction.Increase,
+            UInt64.fromUint(10),
+            NetworkType.MIJIN_TEST,
+        );
+
+        Object.assign(tx, { signer: account.publicAccount });
+        expect(tx.NotifyAccount(account.address)).to.be.true;
+    });
 });

--- a/test/model/transaction/MultisigAccountModificationTransaction.spec.ts
+++ b/test/model/transaction/MultisigAccountModificationTransaction.spec.ts
@@ -168,14 +168,14 @@ describe('MultisigAccountModificationTransaction', () => {
             NetworkType.MIJIN_TEST,
         );
 
-        let canNotify = txAddition.NotifyAccount(publicAccount.address);
+        let canNotify = txAddition.shouldNotifiAccount(publicAccount.address);
         expect(canNotify).to.be.true;
 
-        canNotify = txAddition.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        canNotify = txAddition.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
         expect(canNotify).to.be.false;
 
         Object.assign(txAddition, { signer: account.publicAccount });
-        expect(txAddition.NotifyAccount(account.address)).to.be.true;
+        expect(txAddition.shouldNotifiAccount(account.address)).to.be.true;
 
         const txDeletion = MultisigAccountModificationTransaction.create(
             Deadline.create(),
@@ -186,13 +186,13 @@ describe('MultisigAccountModificationTransaction', () => {
             NetworkType.MIJIN_TEST,
         );
 
-        let canNotifyDeletion = txDeletion.NotifyAccount(publicAccount.address);
+        let canNotifyDeletion = txDeletion.shouldNotifiAccount(publicAccount.address);
         expect(canNotifyDeletion).to.be.true;
 
-        canNotifyDeletion = txDeletion.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        canNotifyDeletion = txDeletion.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
         expect(canNotifyDeletion).to.be.false;
 
         Object.assign(txDeletion, { signer: account.publicAccount });
-        expect(txDeletion.NotifyAccount(account.address)).to.be.true;
+        expect(txDeletion.shouldNotifiAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/MultisigAccountModificationTransaction.spec.ts
+++ b/test/model/transaction/MultisigAccountModificationTransaction.spec.ts
@@ -23,6 +23,7 @@ import { Deadline } from '../../../src/model/transaction/Deadline';
 import { MultisigAccountModificationTransaction } from '../../../src/model/transaction/MultisigAccountModificationTransaction';
 import { UInt64 } from '../../../src/model/UInt64';
 import { TestingAccount } from '../../conf/conf.spec';
+import { Address } from '../../../src/model/account/Address';
 
 describe('MultisigAccountModificationTransaction', () => {
     let account: Account;
@@ -151,5 +152,47 @@ describe('MultisigAccountModificationTransaction', () => {
 
         const signedTransaction = modifyMultisigAccountTransaction.signWith(account, generationHash);
         expect(signedTransaction.hash).not.to.be.undefined;
+    });
+
+    it('Notify Account', () => {
+        const publicAccount = PublicAccount.createFromPublicKey(
+            'B0F93CBEE49EEB9953C6F3985B15A4F238E205584D8F924C621CBE4D7AC6EC24',
+            NetworkType.MIJIN_TEST,
+        );
+        const txAddition = MultisigAccountModificationTransaction.create(
+            Deadline.create(),
+            1,
+            1,
+            [publicAccount],
+            [],
+            NetworkType.MIJIN_TEST,
+        );
+
+        let canNotify = txAddition.NotifyAccount(publicAccount.address);
+        expect(canNotify).to.be.true;
+
+        canNotify = txAddition.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        expect(canNotify).to.be.false;
+
+        Object.assign(txAddition, { signer: account.publicAccount });
+        expect(txAddition.NotifyAccount(account.address)).to.be.true;
+
+        const txDeletion = MultisigAccountModificationTransaction.create(
+            Deadline.create(),
+            1,
+            1,
+            [],
+            [publicAccount],
+            NetworkType.MIJIN_TEST,
+        );
+
+        let canNotifyDeletion = txDeletion.NotifyAccount(publicAccount.address);
+        expect(canNotifyDeletion).to.be.true;
+
+        canNotifyDeletion = txDeletion.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        expect(canNotifyDeletion).to.be.false;
+
+        Object.assign(txDeletion, { signer: account.publicAccount });
+        expect(txDeletion.NotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/MultisigAccountModificationTransaction.spec.ts
+++ b/test/model/transaction/MultisigAccountModificationTransaction.spec.ts
@@ -168,14 +168,14 @@ describe('MultisigAccountModificationTransaction', () => {
             NetworkType.MIJIN_TEST,
         );
 
-        let canNotify = txAddition.shouldNotifiAccount(publicAccount.address);
+        let canNotify = txAddition.shouldNotifyAccount(publicAccount.address);
         expect(canNotify).to.be.true;
 
-        canNotify = txAddition.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        canNotify = txAddition.shouldNotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
         expect(canNotify).to.be.false;
 
         Object.assign(txAddition, { signer: account.publicAccount });
-        expect(txAddition.shouldNotifiAccount(account.address)).to.be.true;
+        expect(txAddition.shouldNotifyAccount(account.address)).to.be.true;
 
         const txDeletion = MultisigAccountModificationTransaction.create(
             Deadline.create(),
@@ -186,13 +186,13 @@ describe('MultisigAccountModificationTransaction', () => {
             NetworkType.MIJIN_TEST,
         );
 
-        let canNotifyDeletion = txDeletion.shouldNotifiAccount(publicAccount.address);
+        let canNotifyDeletion = txDeletion.shouldNotifyAccount(publicAccount.address);
         expect(canNotifyDeletion).to.be.true;
 
-        canNotifyDeletion = txDeletion.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        canNotifyDeletion = txDeletion.shouldNotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
         expect(canNotifyDeletion).to.be.false;
 
         Object.assign(txDeletion, { signer: account.publicAccount });
-        expect(txDeletion.shouldNotifiAccount(account.address)).to.be.true;
+        expect(txDeletion.shouldNotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/NamespaceMetadataTransaction.spec.ts
+++ b/test/model/transaction/NamespaceMetadataTransaction.spec.ts
@@ -26,6 +26,7 @@ import { TestingAccount } from '../../conf/conf.spec';
 import { EmbeddedTransactionBuilder } from 'catbuffer-typescript/dist/EmbeddedTransactionBuilder';
 import { TransactionType } from '../../../src/model/transaction/TransactionType';
 import { deepEqual } from 'assert';
+import { Address } from '../../../src/model/account/Address';
 
 describe('NamespaceMetadataTransaction', () => {
     let account: Account;
@@ -150,5 +151,25 @@ describe('NamespaceMetadataTransaction', () => {
 
         expect(resolved).to.be.instanceOf(NamespaceMetadataTransaction);
         deepEqual(namespaceMetadataTransaction, resolved);
+    });
+
+    it('Notify Account', () => {
+        const tx = NamespaceMetadataTransaction.create(
+            Deadline.create(),
+            account.publicKey,
+            UInt64.fromUint(1000),
+            new NamespaceId([2262289484, 3405110546]),
+            1,
+            Convert.uint8ToUtf8(new Uint8Array(10)),
+            NetworkType.MIJIN_TEST,
+        );
+        let canNotify = tx.NotifyAccount(account.address);
+        expect(canNotify).to.be.true;
+
+        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        expect(canNotify).to.be.false;
+
+        Object.assign(tx, { signer: account.publicAccount });
+        expect(tx.NotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/NamespaceMetadataTransaction.spec.ts
+++ b/test/model/transaction/NamespaceMetadataTransaction.spec.ts
@@ -163,13 +163,13 @@ describe('NamespaceMetadataTransaction', () => {
             Convert.uint8ToUtf8(new Uint8Array(10)),
             NetworkType.MIJIN_TEST,
         );
-        let canNotify = tx.NotifyAccount(account.address);
+        let canNotify = tx.shouldNotifiAccount(account.address);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.NotifyAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/NamespaceMetadataTransaction.spec.ts
+++ b/test/model/transaction/NamespaceMetadataTransaction.spec.ts
@@ -163,13 +163,13 @@ describe('NamespaceMetadataTransaction', () => {
             Convert.uint8ToUtf8(new Uint8Array(10)),
             NetworkType.MIJIN_TEST,
         );
-        let canNotify = tx.shouldNotifiAccount(account.address);
+        let canNotify = tx.shouldNotifyAccount(account.address);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        canNotify = tx.shouldNotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/NamespaceRegistrationTransaction.spec.ts
+++ b/test/model/transaction/NamespaceRegistrationTransaction.spec.ts
@@ -129,4 +129,16 @@ describe('NamespaceRegistrationTransaction', () => {
         const signedTransaction = registerNamespaceTransaction.signWith(account, generationHash);
         expect(signedTransaction.hash).not.to.be.undefined;
     });
+
+    it('Notify Account', () => {
+        const tx = NamespaceRegistrationTransaction.createRootNamespace(
+            Deadline.create(),
+            'root-test-namespace',
+            UInt64.fromUint(1000),
+            NetworkType.MIJIN_TEST,
+        );
+
+        Object.assign(tx, { signer: account.publicAccount });
+        expect(tx.NotifyAccount(account.address)).to.be.true;
+    });
 });

--- a/test/model/transaction/NamespaceRegistrationTransaction.spec.ts
+++ b/test/model/transaction/NamespaceRegistrationTransaction.spec.ts
@@ -139,6 +139,6 @@ describe('NamespaceRegistrationTransaction', () => {
         );
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.NotifyAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/NamespaceRegistrationTransaction.spec.ts
+++ b/test/model/transaction/NamespaceRegistrationTransaction.spec.ts
@@ -139,6 +139,6 @@ describe('NamespaceRegistrationTransaction', () => {
         );
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/NodeKeyLinkTransaction.spec.ts
+++ b/test/model/transaction/NodeKeyLinkTransaction.spec.ts
@@ -121,13 +121,13 @@ describe('NodeKeyLinkTransaction', () => {
 
     it('Notify Account', () => {
         const tx = NodeKeyLinkTransaction.create(Deadline.create(), account.publicKey, LinkAction.Unlink, NetworkType.MIJIN_TEST);
-        let canNotify = tx.NotifyAccount(account.address);
+        let canNotify = tx.shouldNotifiAccount(account.address);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.NotifyAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/NodeKeyLinkTransaction.spec.ts
+++ b/test/model/transaction/NodeKeyLinkTransaction.spec.ts
@@ -23,6 +23,7 @@ import { Deadline } from '../../../src/model/transaction/Deadline';
 import { LinkAction } from '../../../src/model/transaction/LinkAction';
 import { UInt64 } from '../../../src/model/UInt64';
 import { TestingAccount } from '../../conf/conf.spec';
+import { Address } from '../../../src/model/account/Address';
 
 describe('NodeKeyLinkTransaction', () => {
     let account: Account;
@@ -116,5 +117,17 @@ describe('NodeKeyLinkTransaction', () => {
 
         const signedTransaction = nodeKeyLinkTransaction.signWith(account, generationHash);
         expect(signedTransaction.hash).not.to.be.undefined;
+    });
+
+    it('Notify Account', () => {
+        const tx = NodeKeyLinkTransaction.create(Deadline.create(), account.publicKey, LinkAction.Unlink, NetworkType.MIJIN_TEST);
+        let canNotify = tx.NotifyAccount(account.address);
+        expect(canNotify).to.be.true;
+
+        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        expect(canNotify).to.be.false;
+
+        Object.assign(tx, { signer: account.publicAccount });
+        expect(tx.NotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/NodeKeyLinkTransaction.spec.ts
+++ b/test/model/transaction/NodeKeyLinkTransaction.spec.ts
@@ -121,13 +121,13 @@ describe('NodeKeyLinkTransaction', () => {
 
     it('Notify Account', () => {
         const tx = NodeKeyLinkTransaction.create(Deadline.create(), account.publicKey, LinkAction.Unlink, NetworkType.MIJIN_TEST);
-        let canNotify = tx.shouldNotifiAccount(account.address);
+        let canNotify = tx.shouldNotifyAccount(account.address);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        canNotify = tx.shouldNotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/SecretLockTransaction.spec.ts
+++ b/test/model/transaction/SecretLockTransaction.spec.ts
@@ -300,4 +300,41 @@ describe('SecretLockTransaction', () => {
         const signedTransaction = secretLockTransaction.signWith(account, generationHash);
         expect(signedTransaction.hash).not.to.be.undefined;
     });
+
+    it('Notify Account', () => {
+        const proof = 'B778A39A3663719DFC5E48C9D78431B1E45C2AF9DF538782BF199C189DABEAC7';
+        const recipientAddress = Address.createFromRawAddress('SDBDG4IT43MPCW2W4CBBCSJJT42AYALQN7A4VVWL');
+        const tx = SecretLockTransaction.create(
+            Deadline.create(),
+            NetworkCurrencyLocal.createAbsolute(10),
+            UInt64.fromUint(100),
+            LockHashAlgorithm.Op_Sha3_256,
+            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            recipientAddress,
+            NetworkType.MIJIN_TEST,
+        );
+        let canNotify = tx.NotifyAccount(recipientAddress, []);
+        expect(canNotify).to.be.true;
+
+        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        expect(canNotify).to.be.false;
+
+        Object.assign(tx, { signer: account.publicAccount });
+        expect(tx.NotifyAccount(account.address, [])).to.be.true;
+    });
+
+    it('Notify Account with alias', () => {
+        const namespaceId = new NamespaceId('test');
+        const proof = 'B778A39A3663719DFC5E48C9D78431B1E45C2AF9DF538782BF199C189DABEAC7';
+        const canNotify = SecretLockTransaction.create(
+            Deadline.create(),
+            NetworkCurrencyLocal.createAbsolute(10),
+            UInt64.fromUint(100),
+            LockHashAlgorithm.Op_Sha3_256,
+            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            account.address,
+            NetworkType.MIJIN_TEST,
+        ).NotifyAccount(account.address, [namespaceId]);
+        expect(canNotify).to.be.true;
+    });
 });

--- a/test/model/transaction/SecretLockTransaction.spec.ts
+++ b/test/model/transaction/SecretLockTransaction.spec.ts
@@ -313,14 +313,14 @@ describe('SecretLockTransaction', () => {
             recipientAddress,
             NetworkType.MIJIN_TEST,
         );
-        let canNotify = tx.shouldNotifiAccount(recipientAddress, []);
+        let canNotify = tx.shouldNotifyAccount(recipientAddress, []);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        canNotify = tx.shouldNotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.shouldNotifiAccount(account.address, [])).to.be.true;
+        expect(tx.shouldNotifyAccount(account.address, [])).to.be.true;
     });
 
     it('Notify Account with alias', () => {
@@ -334,7 +334,7 @@ describe('SecretLockTransaction', () => {
             sha3_256.create().update(convert.hexToUint8(proof)).hex(),
             account.address,
             NetworkType.MIJIN_TEST,
-        ).shouldNotifiAccount(account.address, [namespaceId]);
+        ).shouldNotifyAccount(account.address, [namespaceId]);
         expect(canNotify).to.be.true;
     });
 });

--- a/test/model/transaction/SecretLockTransaction.spec.ts
+++ b/test/model/transaction/SecretLockTransaction.spec.ts
@@ -313,14 +313,14 @@ describe('SecretLockTransaction', () => {
             recipientAddress,
             NetworkType.MIJIN_TEST,
         );
-        let canNotify = tx.NotifyAccount(recipientAddress, []);
+        let canNotify = tx.shouldNotifiAccount(recipientAddress, []);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.NotifyAccount(account.address, [])).to.be.true;
+        expect(tx.shouldNotifiAccount(account.address, [])).to.be.true;
     });
 
     it('Notify Account with alias', () => {
@@ -334,7 +334,7 @@ describe('SecretLockTransaction', () => {
             sha3_256.create().update(convert.hexToUint8(proof)).hex(),
             account.address,
             NetworkType.MIJIN_TEST,
-        ).NotifyAccount(account.address, [namespaceId]);
+        ).shouldNotifiAccount(account.address, [namespaceId]);
         expect(canNotify).to.be.true;
     });
 });

--- a/test/model/transaction/SecretProofTransaction.spec.ts
+++ b/test/model/transaction/SecretProofTransaction.spec.ts
@@ -299,4 +299,38 @@ describe('SecretProofTransaction', () => {
         expect(secretBytes).not.to.be.undefined;
         expect(Convert.uint8ToHex(secretBytes)).to.be.equal('9B3155B37159DA50AA52D5967C509B410F5A36A3B1E31ECB5AC76675D79B4A5E');
     });
+
+    it('Notify Account', () => {
+        const proof = 'B778A39A3663719DFC5E48C9D78431B1E45C2AF9DF538782BF199C189DABEAC7';
+        const tx = SecretProofTransaction.create(
+            Deadline.create(),
+            LockHashAlgorithm.Op_Sha3_256,
+            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            account.address,
+            proof,
+            NetworkType.MIJIN_TEST,
+        );
+        let canNotify = tx.NotifyAccount(account.address, []);
+        expect(canNotify).to.be.true;
+
+        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        expect(canNotify).to.be.false;
+
+        Object.assign(tx, { signer: account.publicAccount });
+        expect(tx.NotifyAccount(account.address, [])).to.be.true;
+    });
+
+    it('Notify Account with alias', () => {
+        const namespaceId = new NamespaceId('test');
+        const proof = 'B778A39A3663719DFC5E48C9D78431B1E45C2AF9DF538782BF199C189DABEAC7';
+        const canNotify = SecretProofTransaction.create(
+            Deadline.create(),
+            LockHashAlgorithm.Op_Sha3_256,
+            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            account.address,
+            proof,
+            NetworkType.MIJIN_TEST,
+        ).NotifyAccount(account.address, [namespaceId]);
+        expect(canNotify).to.be.true;
+    });
 });

--- a/test/model/transaction/SecretProofTransaction.spec.ts
+++ b/test/model/transaction/SecretProofTransaction.spec.ts
@@ -310,14 +310,14 @@ describe('SecretProofTransaction', () => {
             proof,
             NetworkType.MIJIN_TEST,
         );
-        let canNotify = tx.NotifyAccount(account.address, []);
+        let canNotify = tx.shouldNotifiAccount(account.address, []);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.NotifyAccount(account.address, [])).to.be.true;
+        expect(tx.shouldNotifiAccount(account.address, [])).to.be.true;
     });
 
     it('Notify Account with alias', () => {
@@ -330,7 +330,7 @@ describe('SecretProofTransaction', () => {
             account.address,
             proof,
             NetworkType.MIJIN_TEST,
-        ).NotifyAccount(account.address, [namespaceId]);
+        ).shouldNotifiAccount(account.address, [namespaceId]);
         expect(canNotify).to.be.true;
     });
 });

--- a/test/model/transaction/SecretProofTransaction.spec.ts
+++ b/test/model/transaction/SecretProofTransaction.spec.ts
@@ -310,14 +310,14 @@ describe('SecretProofTransaction', () => {
             proof,
             NetworkType.MIJIN_TEST,
         );
-        let canNotify = tx.shouldNotifiAccount(account.address, []);
+        let canNotify = tx.shouldNotifyAccount(account.address, []);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        canNotify = tx.shouldNotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.shouldNotifiAccount(account.address, [])).to.be.true;
+        expect(tx.shouldNotifyAccount(account.address, [])).to.be.true;
     });
 
     it('Notify Account with alias', () => {
@@ -330,7 +330,7 @@ describe('SecretProofTransaction', () => {
             account.address,
             proof,
             NetworkType.MIJIN_TEST,
-        ).shouldNotifiAccount(account.address, [namespaceId]);
+        ).shouldNotifyAccount(account.address, [namespaceId]);
         expect(canNotify).to.be.true;
     });
 });

--- a/test/model/transaction/Transaction.spec.ts
+++ b/test/model/transaction/Transaction.spec.ts
@@ -30,6 +30,7 @@ import { TransactionType } from '../../../src/model/transaction/TransactionType'
 import { TransferTransaction } from '../../../src/model/transaction/TransferTransaction';
 import { UInt64 } from '../../../src/model/UInt64';
 import { TestingAccount } from '../../conf/conf.spec';
+import { NamespaceId } from '../../../src/model/namespace/NamespaceId';
 
 describe('Transaction', () => {
     let account: Account;
@@ -48,6 +49,11 @@ describe('Transaction', () => {
         }
 
         public toEmbeddedTransaction(): EmbeddedTransactionBuilder {
+            throw new Error('Not implemented');
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        public NotifyAccount(address: Address, alias: NamespaceId[]): boolean {
             throw new Error('Not implemented');
         }
         resolveAliases(): TransferTransaction {

--- a/test/model/transaction/Transaction.spec.ts
+++ b/test/model/transaction/Transaction.spec.ts
@@ -54,7 +54,7 @@ describe('Transaction', () => {
         }
 
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        public shouldNotifiAccount(address: Address, alias: NamespaceId[]): boolean {
+        public shouldNotifyAccount(address: Address, alias: NamespaceId[]): boolean {
             throw new Error('Not implemented');
         }
         resolveAliases(): TransferTransaction {

--- a/test/model/transaction/Transaction.spec.ts
+++ b/test/model/transaction/Transaction.spec.ts
@@ -31,6 +31,7 @@ import { TransferTransaction } from '../../../src/model/transaction/TransferTran
 import { UInt64 } from '../../../src/model/UInt64';
 import { TestingAccount } from '../../conf/conf.spec';
 import { NamespaceId } from '../../../src/model/namespace/NamespaceId';
+import { TransactionMapping } from '../../../src/core/utils/TransactionMapping';
 
 describe('Transaction', () => {
     let account: Account;
@@ -53,7 +54,7 @@ describe('Transaction', () => {
         }
 
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        public NotifyAccount(address: Address, alias: NamespaceId[]): boolean {
+        public shouldNotifiAccount(address: Address, alias: NamespaceId[]): boolean {
             throw new Error('Not implemented');
         }
         resolveAliases(): TransferTransaction {
@@ -385,5 +386,21 @@ describe('Transaction', () => {
             expect(hash1).to.equal(hashTamperedBody);
             expect(hash1).to.not.equal(hashTamperedMerkle);
         });
+    });
+
+    it('is signed', () => {
+        let tx = TransferTransaction.create(
+            Deadline.create(),
+            Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC'),
+            [],
+            PlainMessage.create('test-message'),
+            NetworkType.MIJIN_TEST,
+        ) as Transaction;
+
+        expect(tx.isSigned(account.address)).to.be.false;
+        const signed = tx.signWith(account, '57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6');
+        tx = TransactionMapping.createFromPayload(signed.payload) as Transaction;
+        expect((tx as Transaction).isSigned(account.address)).to.be.true;
+        expect((tx as Transaction).isSigned(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYZC'))).to.be.false;
     });
 });

--- a/test/model/transaction/TransferTransaction.spec.ts
+++ b/test/model/transaction/TransferTransaction.spec.ts
@@ -423,4 +423,36 @@ describe('TransferTransaction', () => {
         const signedTransaction = transferTransaction.signWith(account, generationHash);
         expect(signedTransaction.hash).not.to.be.undefined;
     });
+
+    it('Notify Account', () => {
+        const address = Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
+        const tx = TransferTransaction.create(
+            Deadline.create(),
+            address,
+            [NetworkCurrencyLocal.createAbsolute(1)],
+            PlainMessage.create('test-message'),
+            NetworkType.MIJIN_TEST,
+        );
+        let canNotify = tx.NotifyAccount(address, []);
+        expect(canNotify).to.be.true;
+
+        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        expect(canNotify).to.be.false;
+
+        Object.assign(tx, { signer: account.publicAccount });
+        expect(tx.NotifyAccount(account.address, [])).to.be.true;
+    });
+
+    it('Notify Account with alias', () => {
+        const address = Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
+        const namespaceId = new NamespaceId('test');
+        const canNotify = TransferTransaction.create(
+            Deadline.create(),
+            namespaceId,
+            [NetworkCurrencyLocal.createAbsolute(1)],
+            PlainMessage.create('test-message'),
+            NetworkType.MIJIN_TEST,
+        ).NotifyAccount(address, [namespaceId]);
+        expect(canNotify).to.be.true;
+    });
 });

--- a/test/model/transaction/TransferTransaction.spec.ts
+++ b/test/model/transaction/TransferTransaction.spec.ts
@@ -433,14 +433,14 @@ describe('TransferTransaction', () => {
             PlainMessage.create('test-message'),
             NetworkType.MIJIN_TEST,
         );
-        let canNotify = tx.shouldNotifiAccount(address, []);
+        let canNotify = tx.shouldNotifyAccount(address, []);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        canNotify = tx.shouldNotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.shouldNotifiAccount(account.address, [])).to.be.true;
+        expect(tx.shouldNotifyAccount(account.address, [])).to.be.true;
     });
 
     it('Notify Account with alias', () => {
@@ -452,7 +452,7 @@ describe('TransferTransaction', () => {
             [NetworkCurrencyLocal.createAbsolute(1)],
             PlainMessage.create('test-message'),
             NetworkType.MIJIN_TEST,
-        ).shouldNotifiAccount(address, [namespaceId]);
+        ).shouldNotifyAccount(address, [namespaceId]);
         expect(canNotify).to.be.true;
     });
 });

--- a/test/model/transaction/TransferTransaction.spec.ts
+++ b/test/model/transaction/TransferTransaction.spec.ts
@@ -433,14 +433,14 @@ describe('TransferTransaction', () => {
             PlainMessage.create('test-message'),
             NetworkType.MIJIN_TEST,
         );
-        let canNotify = tx.NotifyAccount(address, []);
+        let canNotify = tx.shouldNotifiAccount(address, []);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
+        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'), []);
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.NotifyAccount(account.address, [])).to.be.true;
+        expect(tx.shouldNotifiAccount(account.address, [])).to.be.true;
     });
 
     it('Notify Account with alias', () => {
@@ -452,7 +452,7 @@ describe('TransferTransaction', () => {
             [NetworkCurrencyLocal.createAbsolute(1)],
             PlainMessage.create('test-message'),
             NetworkType.MIJIN_TEST,
-        ).NotifyAccount(address, [namespaceId]);
+        ).shouldNotifiAccount(address, [namespaceId]);
         expect(canNotify).to.be.true;
     });
 });

--- a/test/model/transaction/VotingKeyLinkTransaction.spec.ts
+++ b/test/model/transaction/VotingKeyLinkTransaction.spec.ts
@@ -123,13 +123,13 @@ describe('VotingKeyLinkTransaction', () => {
 
     it('Notify Account', () => {
         const tx = VotingKeyLinkTransaction.create(Deadline.create(), account.publicKey, LinkAction.Unlink, NetworkType.MIJIN_TEST);
-        let canNotify = tx.shouldNotifiAccount(account.address);
+        let canNotify = tx.shouldNotifyAccount(account.address);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        canNotify = tx.shouldNotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/VotingKeyLinkTransaction.spec.ts
+++ b/test/model/transaction/VotingKeyLinkTransaction.spec.ts
@@ -23,6 +23,7 @@ import { Deadline } from '../../../src/model/transaction/Deadline';
 import { LinkAction } from '../../../src/model/transaction/LinkAction';
 import { UInt64 } from '../../../src/model/UInt64';
 import { TestingAccount } from '../../conf/conf.spec';
+import { Address } from '../../../src/model/account/Address';
 
 describe('VotingKeyLinkTransaction', () => {
     let account: Account;
@@ -118,5 +119,17 @@ describe('VotingKeyLinkTransaction', () => {
 
         const signedTransaction = votingKeyLinkTransaction.signWith(account, generationHash);
         expect(signedTransaction.hash).not.to.be.undefined;
+    });
+
+    it('Notify Account', () => {
+        const tx = VotingKeyLinkTransaction.create(Deadline.create(), account.publicKey, LinkAction.Unlink, NetworkType.MIJIN_TEST);
+        let canNotify = tx.NotifyAccount(account.address);
+        expect(canNotify).to.be.true;
+
+        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        expect(canNotify).to.be.false;
+
+        Object.assign(tx, { signer: account.publicAccount });
+        expect(tx.NotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/VotingKeyLinkTransaction.spec.ts
+++ b/test/model/transaction/VotingKeyLinkTransaction.spec.ts
@@ -123,13 +123,13 @@ describe('VotingKeyLinkTransaction', () => {
 
     it('Notify Account', () => {
         const tx = VotingKeyLinkTransaction.create(Deadline.create(), account.publicKey, LinkAction.Unlink, NetworkType.MIJIN_TEST);
-        let canNotify = tx.NotifyAccount(account.address);
+        let canNotify = tx.shouldNotifiAccount(account.address);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.NotifyAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/VrfKeyLinkTransaction.spec.ts
+++ b/test/model/transaction/VrfKeyLinkTransaction.spec.ts
@@ -121,13 +121,13 @@ describe('VrfKeyLinkTransaction', () => {
 
     it('Notify Account', () => {
         const tx = VrfKeyLinkTransaction.create(Deadline.create(), account.publicKey, LinkAction.Unlink, NetworkType.MIJIN_TEST);
-        let canNotify = tx.NotifyAccount(account.address);
+        let canNotify = tx.shouldNotifiAccount(account.address);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.NotifyAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/VrfKeyLinkTransaction.spec.ts
+++ b/test/model/transaction/VrfKeyLinkTransaction.spec.ts
@@ -121,13 +121,13 @@ describe('VrfKeyLinkTransaction', () => {
 
     it('Notify Account', () => {
         const tx = VrfKeyLinkTransaction.create(Deadline.create(), account.publicKey, LinkAction.Unlink, NetworkType.MIJIN_TEST);
-        let canNotify = tx.shouldNotifiAccount(account.address);
+        let canNotify = tx.shouldNotifyAccount(account.address);
         expect(canNotify).to.be.true;
 
-        canNotify = tx.shouldNotifiAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        canNotify = tx.shouldNotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
         expect(canNotify).to.be.false;
 
         Object.assign(tx, { signer: account.publicAccount });
-        expect(tx.shouldNotifiAccount(account.address)).to.be.true;
+        expect(tx.shouldNotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/model/transaction/VrfKeyLinkTransaction.spec.ts
+++ b/test/model/transaction/VrfKeyLinkTransaction.spec.ts
@@ -23,6 +23,7 @@ import { Deadline } from '../../../src/model/transaction/Deadline';
 import { LinkAction } from '../../../src/model/transaction/LinkAction';
 import { UInt64 } from '../../../src/model/UInt64';
 import { TestingAccount } from '../../conf/conf.spec';
+import { Address } from '../../../src/model/account/Address';
 
 describe('VrfKeyLinkTransaction', () => {
     let account: Account;
@@ -116,5 +117,17 @@ describe('VrfKeyLinkTransaction', () => {
 
         const signedTransaction = vrfKeyLinkTransaction.signWith(account, generationHash);
         expect(signedTransaction.hash).not.to.be.undefined;
+    });
+
+    it('Notify Account', () => {
+        const tx = VrfKeyLinkTransaction.create(Deadline.create(), account.publicKey, LinkAction.Unlink, NetworkType.MIJIN_TEST);
+        let canNotify = tx.NotifyAccount(account.address);
+        expect(canNotify).to.be.true;
+
+        canNotify = tx.NotifyAccount(Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKB'));
+        expect(canNotify).to.be.false;
+
+        Object.assign(tx, { signer: account.publicAccount });
+        expect(tx.NotifyAccount(account.address)).to.be.true;
     });
 });

--- a/test/service/TransactionService.spec.ts
+++ b/test/service/TransactionService.spec.ts
@@ -95,7 +95,7 @@ describe('TransactionService', () => {
             observableOf(transferTransaction),
         );
 
-        when(listener.status(deepEqual(account.address))).thenReturn(EMPTY);
+        when(listener.status(deepEqual(account.address), signedTransaction.hash)).thenReturn(EMPTY);
 
         const service = new TransactionService(instance(transactionRepositoryMock), instance(mockedReceiptRepository));
 
@@ -114,7 +114,7 @@ describe('TransactionService', () => {
 
         when(listener.confirmed(deepEqual(account.address), deepEqual(signedTransaction.hash))).thenReturn(EMPTY);
         const statusError = new TransactionStatusError(account.address, signedTransaction.hash, 'Some Error', Deadline.create());
-        when(listener.status(deepEqual(account.address))).thenReturn(observableOf(statusError));
+        when(listener.status(deepEqual(account.address), signedTransaction.hash)).thenReturn(observableOf(statusError));
 
         const service = new TransactionService(instance(transactionRepositoryMock), instance(mockedReceiptRepository));
 
@@ -139,7 +139,7 @@ describe('TransactionService', () => {
         when(listener.aggregateBondedAdded(deepEqual(account.address), deepEqual(signedTransaction.hash))).thenReturn(
             observableOf(aggregateCompleteTransaction),
         );
-        when(listener.status(deepEqual(account.address))).thenReturn(EMPTY);
+        when(listener.status(deepEqual(account.address), signedTransaction.hash)).thenReturn(EMPTY);
 
         const service = new TransactionService(instance(transactionRepositoryMock), instance(mockedReceiptRepository));
 
@@ -160,7 +160,7 @@ describe('TransactionService', () => {
 
         when(listener.aggregateBondedAdded(deepEqual(account.address), deepEqual(signedTransaction.hash))).thenReturn(EMPTY);
         const statusError = new TransactionStatusError(account.address, signedTransaction.hash, 'Some Error', Deadline.create());
-        when(listener.status(deepEqual(account.address))).thenReturn(observableOf(statusError));
+        when(listener.status(deepEqual(account.address), signedTransaction.hash)).thenReturn(observableOf(statusError));
 
         const service = new TransactionService(instance(transactionRepositoryMock), instance(mockedReceiptRepository));
 
@@ -196,7 +196,7 @@ describe('TransactionService', () => {
             observableOf(aggregateBondedTransaction),
         );
 
-        when(listener.status(deepEqual(account.address))).thenReturn(EMPTY);
+        when(listener.status(deepEqual(account.address), hashLockSignedTransaction.hash)).thenReturn(EMPTY);
 
         const service = new TransactionService(instance(transactionRepositoryMock), instance(mockedReceiptRepository));
 


### PR DESCRIPTION
#### Issue: 
- Listener channels currently only filter on 'signer' and 'recipientAddress' in TransferTransaction only.
- Does not resolve alias (unresolvedAddress). e.g. Transfer's recipientAddress is an instance of NamespaceId

#### Fixed:
- Added abstract method in Transactions for listener notification filtering purposes. 
- Filters on address / publicAccount / publicKeys on all transactions. e.g. 'targetAccount' in MetadataTransactions.
- Added `NamespaceRepository` to `Listener` to resolve alias.
Fixed #569