### PR TITLE
Added signature and signer to loadFromPayload

### DIFF
--- a/src/model/transaction/AccountKeyLinkTransaction.ts
+++ b/src/model/transaction/AccountKeyLinkTransaction.ts
@@ -46,6 +46,8 @@ export class AccountKeyLinkTransaction extends Transaction {
      * @param remotePublicKey - The public key of the remote account.
      * @param linkAction - The account link action.
      * @param maxFee - (Optional) Max fee defined by the sender
+     * @param signature - (Optional) Transaction signature
+     * @param signer - (Optional) Signer public account
      * @returns {AccountLinkTransaction}
      */
     public static create(
@@ -54,6 +56,8 @@ export class AccountKeyLinkTransaction extends Transaction {
         linkAction: LinkAction,
         networkType: NetworkType,
         maxFee: UInt64 = new UInt64([0, 0]),
+        signature?: string,
+        signer?: PublicAccount,
     ): AccountKeyLinkTransaction {
         return new AccountKeyLinkTransaction(
             networkType,
@@ -62,6 +66,8 @@ export class AccountKeyLinkTransaction extends Transaction {
             maxFee,
             remotePublicKey,
             linkAction,
+            signature,
+            signer,
         );
     }
 
@@ -108,12 +114,15 @@ export class AccountKeyLinkTransaction extends Transaction {
             : AccountKeyLinkTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
         const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
         const networkType = builder.getNetwork().valueOf();
+        const signature = payload.substring(16, 144);
         const transaction = AccountKeyLinkTransaction.create(
             isEmbedded ? Deadline.create() : Deadline.createFromDTO((builder as AccountKeyLinkTransactionBuilder).getDeadline().timestamp),
             Convert.uint8ToHex(builder.getRemotePublicKey().key),
             builder.getLinkAction().valueOf(),
             networkType,
             isEmbedded ? new UInt64([0, 0]) : new UInt64((builder as AccountKeyLinkTransactionBuilder).fee.amount),
+            isEmbedded || signature.match(`^[0]+$`) ? undefined : signature,
+            signerPublicKey.match(`^[0]+$`) ? undefined : PublicAccount.createFromPublicKey(signerPublicKey, networkType),
         );
         return isEmbedded ? transaction.toAggregate(PublicAccount.createFromPublicKey(signerPublicKey, networkType)) : transaction;
     }
@@ -139,8 +148,8 @@ export class AccountKeyLinkTransaction extends Transaction {
      * @returns {Uint8Array}
      */
     protected generateBytes(): Uint8Array {
-        const signerBuffer = new Uint8Array(32);
-        const signatureBuffer = new Uint8Array(64);
+        const signerBuffer = this.signer !== undefined ? Convert.hexToUint8(this.signer.publicKey) : new Uint8Array(32);
+        const signatureBuffer = this.signature !== undefined ? Convert.hexToUint8(this.signature) : new Uint8Array(64);
 
         const transactionBuilder = new AccountKeyLinkTransactionBuilder(
             new SignatureDto(signatureBuffer),

--- a/src/model/transaction/AccountMosaicRestrictionTransaction.ts
+++ b/src/model/transaction/AccountMosaicRestrictionTransaction.ts
@@ -50,6 +50,8 @@ export class AccountMosaicRestrictionTransaction extends Transaction {
      * @param restrictionDeletions - Account restriction deletions.
      * @param networkType - The network type.
      * @param maxFee - (Optional) Max fee defined by the sender
+     * @param signature - (Optional) Transaction signature
+     * @param signer - (Optional) Signer public account
      * @returns {AccountAddressRestrictionTransaction}
      */
     public static create(
@@ -59,6 +61,8 @@ export class AccountMosaicRestrictionTransaction extends Transaction {
         restrictionDeletions: (MosaicId | NamespaceId)[],
         networkType: NetworkType,
         maxFee: UInt64 = new UInt64([0, 0]),
+        signature?: string,
+        signer?: PublicAccount,
     ): AccountMosaicRestrictionTransaction {
         return new AccountMosaicRestrictionTransaction(
             networkType,
@@ -68,6 +72,8 @@ export class AccountMosaicRestrictionTransaction extends Transaction {
             restrictionFlags,
             restrictionAdditions,
             restrictionDeletions,
+            signature,
+            signer,
         );
     }
 
@@ -110,6 +116,7 @@ export class AccountMosaicRestrictionTransaction extends Transaction {
             : AccountMosaicRestrictionTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
         const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
         const networkType = builder.getNetwork().valueOf();
+        const signature = payload.substring(16, 144);
         const transaction = AccountMosaicRestrictionTransaction.create(
             isEmbedded
                 ? Deadline.create()
@@ -123,6 +130,8 @@ export class AccountMosaicRestrictionTransaction extends Transaction {
             }),
             networkType,
             isEmbedded ? new UInt64([0, 0]) : new UInt64((builder as AccountMosaicRestrictionTransactionBuilder).fee.amount),
+            isEmbedded || signature.match(`^[0]+$`) ? undefined : signature,
+            signerPublicKey.match(`^[0]+$`) ? undefined : PublicAccount.createFromPublicKey(signerPublicKey, networkType),
         );
         return isEmbedded ? transaction.toAggregate(PublicAccount.createFromPublicKey(signerPublicKey, networkType)) : transaction;
     }
@@ -160,8 +169,8 @@ export class AccountMosaicRestrictionTransaction extends Transaction {
      * @returns {Uint8Array}
      */
     protected generateBytes(): Uint8Array {
-        const signerBuffer = new Uint8Array(32);
-        const signatureBuffer = new Uint8Array(64);
+        const signerBuffer = this.signer !== undefined ? Convert.hexToUint8(this.signer.publicKey) : new Uint8Array(32);
+        const signatureBuffer = this.signature !== undefined ? Convert.hexToUint8(this.signature) : new Uint8Array(64);
 
         const transactionBuilder = new AccountMosaicRestrictionTransactionBuilder(
             new SignatureDto(signatureBuffer),

--- a/src/model/transaction/AccountOperationRestrictionTransaction.ts
+++ b/src/model/transaction/AccountOperationRestrictionTransaction.ts
@@ -44,6 +44,8 @@ export class AccountOperationRestrictionTransaction extends Transaction {
      * @param restrictionDeletions - Account restriction deletions.
      * @param networkType - The network type.
      * @param maxFee - (Optional) Max fee defined by the sender
+     * @param signature - (Optional) Transaction signature
+     * @param signer - (Optional) Signer public account
      * @returns {AccountOperationRestrictionTransaction}
      */
     public static create(
@@ -53,6 +55,8 @@ export class AccountOperationRestrictionTransaction extends Transaction {
         restrictionDeletions: TransactionType[],
         networkType: NetworkType,
         maxFee: UInt64 = new UInt64([0, 0]),
+        signature?: string,
+        signer?: PublicAccount,
     ): AccountOperationRestrictionTransaction {
         return new AccountOperationRestrictionTransaction(
             networkType,
@@ -62,6 +66,8 @@ export class AccountOperationRestrictionTransaction extends Transaction {
             restrictionFlags,
             restrictionAdditions,
             restrictionDeletions,
+            signature,
+            signer,
         );
     }
 
@@ -104,6 +110,7 @@ export class AccountOperationRestrictionTransaction extends Transaction {
             : AccountOperationRestrictionTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
         const signer = Convert.uint8ToHex(builder.getSignerPublicKey().key);
         const networkType = builder.getNetwork().valueOf();
+        const signature = payload.substring(16, 144);
         const transaction = AccountOperationRestrictionTransaction.create(
             isEmbedded
                 ? Deadline.create()
@@ -113,6 +120,8 @@ export class AccountOperationRestrictionTransaction extends Transaction {
             builder.getRestrictionDeletions(),
             networkType,
             isEmbedded ? new UInt64([0, 0]) : new UInt64((builder as AccountOperationRestrictionTransactionBuilder).fee.amount),
+            isEmbedded || signature.match(`^[0]+$`) ? undefined : signature,
+            signer.match(`^[0]+$`) ? undefined : PublicAccount.createFromPublicKey(signer, networkType),
         );
         return isEmbedded ? transaction.toAggregate(PublicAccount.createFromPublicKey(signer, networkType)) : transaction;
     }
@@ -150,8 +159,8 @@ export class AccountOperationRestrictionTransaction extends Transaction {
      * @returns {Uint8Array}
      */
     protected generateBytes(): Uint8Array {
-        const signerBuffer = new Uint8Array(32);
-        const signatureBuffer = new Uint8Array(64);
+        const signerBuffer = this.signer !== undefined ? Convert.hexToUint8(this.signer.publicKey) : new Uint8Array(32);
+        const signatureBuffer = this.signature !== undefined ? Convert.hexToUint8(this.signature) : new Uint8Array(64);
 
         const transactionBuilder = new AccountOperationRestrictionTransactionBuilder(
             new SignatureDto(signatureBuffer),

--- a/src/model/transaction/AccountRestrictionTransaction.ts
+++ b/src/model/transaction/AccountRestrictionTransaction.ts
@@ -25,6 +25,7 @@ import { AccountMosaicRestrictionTransaction } from './AccountMosaicRestrictionT
 import { AccountOperationRestrictionTransaction } from './AccountOperationRestrictionTransaction';
 import { Deadline } from './Deadline';
 import { TransactionType } from './TransactionType';
+import { PublicAccount } from '../account/PublicAccount';
 
 export class AccountRestrictionTransaction {
     /**
@@ -35,6 +36,8 @@ export class AccountRestrictionTransaction {
      * @param restrictionDeletions - Account restriction deletions.
      * @param networkType - The network type.
      * @param maxFee - (Optional) Max fee defined by the sender
+     * @param signature - (Optional) Transaction signature
+     * @param signer - (Optional) Signer public account
      * @returns {AccountAddressRestrictionTransaction}
      */
     public static createAddressRestrictionModificationTransaction(
@@ -44,6 +47,8 @@ export class AccountRestrictionTransaction {
         restrictionDeletions: (Address | NamespaceId)[],
         networkType: NetworkType,
         maxFee: UInt64 = new UInt64([0, 0]),
+        signature?: string,
+        signer?: PublicAccount,
     ): AccountAddressRestrictionTransaction {
         if (
             ![
@@ -62,6 +67,8 @@ export class AccountRestrictionTransaction {
             restrictionDeletions,
             networkType,
             maxFee,
+            signature,
+            signer,
         );
     }
 
@@ -73,6 +80,8 @@ export class AccountRestrictionTransaction {
      * @param restrictionDeletions - Account restriction deletions.
      * @param networkType - The network type.
      * @param maxFee - (Optional) Max fee defined by the sender
+     * @param signature - (Optional) Transaction signature
+     * @param signer - (Optional) Signer public account
      * @returns {AccountMosaicRestrictionTransaction}
      */
     public static createMosaicRestrictionModificationTransaction(
@@ -82,6 +91,8 @@ export class AccountRestrictionTransaction {
         restrictionDeletions: (MosaicId | NamespaceId)[],
         networkType: NetworkType,
         maxFee: UInt64 = new UInt64([0, 0]),
+        signature?: string,
+        signer?: PublicAccount,
     ): AccountMosaicRestrictionTransaction {
         if (![AccountRestrictionFlags.AllowMosaic, AccountRestrictionFlags.BlockMosaic].includes(restrictionFlags)) {
             throw new Error('Restriction type is not allowed.');
@@ -93,6 +104,8 @@ export class AccountRestrictionTransaction {
             restrictionDeletions,
             networkType,
             maxFee,
+            signature,
+            signer,
         );
     }
 
@@ -104,6 +117,8 @@ export class AccountRestrictionTransaction {
      * @param restrictionDeletions - Account restriction deletions.
      * @param networkType - The network type.
      * @param maxFee - (Optional) Max fee defined by the sender
+     * @param signature - (Optional) Transaction signature
+     * @param signer - (Optional) Signer public account
      * @returns {AccountOperationRestrictionTransaction}
      */
     public static createOperationRestrictionModificationTransaction(
@@ -113,6 +128,8 @@ export class AccountRestrictionTransaction {
         restrictionDeletions: TransactionType[],
         networkType: NetworkType,
         maxFee: UInt64 = new UInt64([0, 0]),
+        signature?: string,
+        signer?: PublicAccount,
     ): AccountOperationRestrictionTransaction {
         if (
             ![AccountRestrictionFlags.AllowOutgoingTransactionType, AccountRestrictionFlags.BlockOutgoingTransactionType].includes(
@@ -128,6 +145,8 @@ export class AccountRestrictionTransaction {
             restrictionDeletions,
             networkType,
             maxFee,
+            signature,
+            signer,
         );
     }
 }

--- a/src/model/transaction/AggregateTransaction.ts
+++ b/src/model/transaction/AggregateTransaction.ts
@@ -90,6 +90,8 @@ export class AggregateTransaction extends Transaction {
      * @param networkType - The network type.
      * @param cosignatures
      * @param maxFee - (Optional) Max fee defined by the sender
+     * @param signature - (Optional) Transaction signature
+     * @param signer - (Optional) Signer public account
      * @returns {AggregateTransaction}
      */
     public static createComplete(
@@ -98,6 +100,8 @@ export class AggregateTransaction extends Transaction {
         networkType: NetworkType,
         cosignatures: AggregateTransactionCosignature[],
         maxFee: UInt64 = new UInt64([0, 0]),
+        signature?: string,
+        signer?: PublicAccount,
     ): AggregateTransaction {
         return new AggregateTransaction(
             networkType,
@@ -107,6 +111,8 @@ export class AggregateTransaction extends Transaction {
             maxFee,
             innerTransactions,
             cosignatures,
+            signature,
+            signer,
         );
     }
 
@@ -117,6 +123,8 @@ export class AggregateTransaction extends Transaction {
      * @param {NetworkType} networkType
      * @param {AggregateTransactionCosignature[]} cosignatures
      * @param {UInt64} maxFee - (Optional) Max fee defined by the sender
+     * @param {string} signature - (Optional) Transaction signature
+     * @param {PublicAccount} signer - (Optional) Signer public account
      * @return {AggregateTransaction}
      */
     public static createBonded(
@@ -125,6 +133,8 @@ export class AggregateTransaction extends Transaction {
         networkType: NetworkType,
         cosignatures: AggregateTransactionCosignature[] = [],
         maxFee: UInt64 = new UInt64([0, 0]),
+        signature?: string,
+        signer?: PublicAccount,
     ): AggregateTransaction {
         return new AggregateTransaction(
             networkType,
@@ -134,6 +144,8 @@ export class AggregateTransaction extends Transaction {
             maxFee,
             innerTransactions,
             cosignatures,
+            signature,
+            signer,
         );
     }
 
@@ -154,6 +166,8 @@ export class AggregateTransaction extends Transaction {
                 : AggregateBondedTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
         const innerTransactions = builder.getTransactions().map((t) => Convert.uint8ToHex(EmbeddedTransactionHelper.serialize(t)));
         const networkType = builder.getNetwork().valueOf();
+        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signature = payload.substring(16, 144);
         const consignatures = builder.getCosignatures().map((cosig) => {
             return new AggregateTransactionCosignature(
                 Convert.uint8ToHex(cosig.signature.signature),
@@ -170,6 +184,8 @@ export class AggregateTransaction extends Transaction {
                   networkType,
                   consignatures,
                   new UInt64(builder.fee.amount),
+                  signature.match(`^[0]+$`) ? undefined : signature,
+                  signerPublicKey.match(`^[0]+$`) ? undefined : PublicAccount.createFromPublicKey(signerPublicKey, networkType),
               )
             : AggregateTransaction.createBonded(
                   Deadline.createFromDTO(builder.deadline.timestamp),
@@ -179,6 +195,8 @@ export class AggregateTransaction extends Transaction {
                   networkType,
                   consignatures,
                   new UInt64(builder.fee.amount),
+                  signature.match(`^[0]+$`) ? undefined : signature,
+                  signerPublicKey.match(`^[0]+$`) ? undefined : PublicAccount.createFromPublicKey(signerPublicKey, networkType),
               );
     }
 
@@ -310,8 +328,8 @@ export class AggregateTransaction extends Transaction {
      * @returns {Uint8Array}
      */
     protected generateBytes(): Uint8Array {
-        const signerBuffer = new Uint8Array(32);
-        const signatureBuffer = new Uint8Array(64);
+        const signerBuffer = this.signer !== undefined ? Convert.hexToUint8(this.signer.publicKey) : new Uint8Array(32);
+        const signatureBuffer = this.signature !== undefined ? Convert.hexToUint8(this.signature) : new Uint8Array(64);
         const transactions = this.innerTransactions.map((transaction) => (transaction as Transaction).toEmbeddedTransaction());
         const cosignatures = this.cosignatures.map((cosignature) => {
             const signerBytes = Convert.hexToUint8(cosignature.signer.publicKey);

--- a/src/model/transaction/AliasTransaction.ts
+++ b/src/model/transaction/AliasTransaction.ts
@@ -24,6 +24,7 @@ import { AddressAliasTransaction } from './AddressAliasTransaction';
 import { Deadline } from './Deadline';
 import { MosaicAliasTransaction } from './MosaicAliasTransaction';
 import { Transaction } from './Transaction';
+import { PublicAccount } from '../account/PublicAccount';
 
 export abstract class AliasTransaction extends Transaction {
     /**
@@ -34,6 +35,8 @@ export abstract class AliasTransaction extends Transaction {
      * @param address - The address.
      * @param networkType - The network type.
      * @param maxFee - (Optional) Max fee defined by the sender
+     * @param signature - (Optional) Transaction signature
+     * @param signer - (Optional) Signer public account
      * @returns {AddressAliasTransaction}
      */
     public static createForAddress(
@@ -43,8 +46,10 @@ export abstract class AliasTransaction extends Transaction {
         address: Address,
         networkType: NetworkType,
         maxFee: UInt64 = new UInt64([0, 0]),
+        signature?: string,
+        signer?: PublicAccount,
     ): AliasTransaction {
-        return AddressAliasTransaction.create(deadline, aliasAction, namespaceId, address, networkType, maxFee);
+        return AddressAliasTransaction.create(deadline, aliasAction, namespaceId, address, networkType, maxFee, signature, signer);
     }
 
     /**
@@ -55,6 +60,8 @@ export abstract class AliasTransaction extends Transaction {
      * @param mosaicId - The mosaic id.
      * @param networkType - The network type.
      * @param maxFee - (Optional) Max fee defined by the sender
+     * @param signature - (Optional) Transaction signature
+     * @param signer - (Optional) Signer public account
      * @returns {MosaicAliasTransaction}
      */
     public static createForMosaic(
@@ -64,7 +71,9 @@ export abstract class AliasTransaction extends Transaction {
         mosaicId: MosaicId,
         networkType: NetworkType,
         maxFee: UInt64 = new UInt64([0, 0]),
+        signature?: string,
+        signer?: PublicAccount,
     ): AliasTransaction {
-        return MosaicAliasTransaction.create(deadline, aliasAction, namespaceId, mosaicId, networkType, maxFee);
+        return MosaicAliasTransaction.create(deadline, aliasAction, namespaceId, mosaicId, networkType, maxFee, signature, signer);
     }
 }

--- a/src/model/transaction/MosaicAddressRestrictionTransaction.ts
+++ b/src/model/transaction/MosaicAddressRestrictionTransaction.ts
@@ -62,6 +62,8 @@ export class MosaicAddressRestrictionTransaction extends Transaction {
      * @param networkType - The network type.
      * @param previousRestrictionValue - (Optional) The previous restriction value.
      * @param maxFee - (Optional) Max fee defined by the sender
+     * @param signature - (Optional) Transaction signature
+     * @param signer - (Optional) Signer public account
      * @returns {MosaicAddressRestrictionTransaction}
      */
     public static create(
@@ -73,6 +75,8 @@ export class MosaicAddressRestrictionTransaction extends Transaction {
         networkType: NetworkType,
         previousRestrictionValue: UInt64 = UInt64.fromHex('FFFFFFFFFFFFFFFF'),
         maxFee: UInt64 = new UInt64([0, 0]),
+        signature?: string,
+        signer?: PublicAccount,
     ): MosaicAddressRestrictionTransaction {
         return new MosaicAddressRestrictionTransaction(
             networkType,
@@ -84,6 +88,8 @@ export class MosaicAddressRestrictionTransaction extends Transaction {
             targetAddress,
             previousRestrictionValue,
             newRestrictionValue,
+            signature,
+            signer,
         );
     }
 
@@ -146,6 +152,7 @@ export class MosaicAddressRestrictionTransaction extends Transaction {
             : MosaicAddressRestrictionTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
         const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
         const networkType = builder.getNetwork().valueOf();
+        const signature = payload.substring(16, 144);
         const transaction = MosaicAddressRestrictionTransaction.create(
             isEmbedded
                 ? Deadline.create()
@@ -157,6 +164,8 @@ export class MosaicAddressRestrictionTransaction extends Transaction {
             networkType,
             new UInt64(builder.getPreviousRestrictionValue()),
             isEmbedded ? new UInt64([0, 0]) : new UInt64((builder as MosaicAddressRestrictionTransactionBuilder).fee.amount),
+            isEmbedded || signature.match(`^[0]+$`) ? undefined : signature,
+            signerPublicKey.match(`^[0]+$`) ? undefined : PublicAccount.createFromPublicKey(signerPublicKey, networkType),
         );
         return isEmbedded ? transaction.toAggregate(PublicAccount.createFromPublicKey(signerPublicKey, networkType)) : transaction;
     }
@@ -200,8 +209,8 @@ export class MosaicAddressRestrictionTransaction extends Transaction {
      * @returns {Uint8Array}
      */
     protected generateBytes(): Uint8Array {
-        const signerBuffer = new Uint8Array(32);
-        const signatureBuffer = new Uint8Array(64);
+        const signerBuffer = this.signer !== undefined ? Convert.hexToUint8(this.signer.publicKey) : new Uint8Array(32);
+        const signatureBuffer = this.signature !== undefined ? Convert.hexToUint8(this.signature) : new Uint8Array(64);
 
         const transactionBuilder = new MosaicAddressRestrictionTransactionBuilder(
             new SignatureDto(signatureBuffer),

--- a/src/model/transaction/MosaicMetadataTransaction.ts
+++ b/src/model/transaction/MosaicMetadataTransaction.ts
@@ -56,6 +56,8 @@ export class MosaicMetadataTransaction extends Transaction {
      *                You can calculate value as xor(previous-value, new-value).
      *                If there is no previous value, use directly the new value.
      * @param maxFee - (Optional) Max fee defined by the sender
+     * @param signature - (Optional) Transaction signature
+     * @param signer - (Optional) Signer public account
      * @returns {MosaicMetadataTransaction}
      */
     public static create(
@@ -67,6 +69,8 @@ export class MosaicMetadataTransaction extends Transaction {
         value: string,
         networkType: NetworkType,
         maxFee: UInt64 = new UInt64([0, 0]),
+        signature?: string,
+        signer?: PublicAccount,
     ): MosaicMetadataTransaction {
         return new MosaicMetadataTransaction(
             networkType,
@@ -78,6 +82,8 @@ export class MosaicMetadataTransaction extends Transaction {
             targetMosaicId,
             valueSizeDelta,
             value,
+            signature,
+            signer,
         );
     }
 
@@ -140,6 +146,7 @@ export class MosaicMetadataTransaction extends Transaction {
             : MosaicMetadataTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
         const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
         const networkType = builder.getNetwork().valueOf();
+        const signature = payload.substring(16, 144);
         const transaction = MosaicMetadataTransaction.create(
             isEmbedded ? Deadline.create() : Deadline.createFromDTO((builder as MosaicMetadataTransactionBuilder).getDeadline().timestamp),
             Convert.uint8ToHex(builder.getTargetPublicKey().key),
@@ -149,6 +156,8 @@ export class MosaicMetadataTransaction extends Transaction {
             Convert.uint8ToUtf8(builder.getValue()),
             networkType,
             isEmbedded ? new UInt64([0, 0]) : new UInt64((builder as MosaicMetadataTransactionBuilder).fee.amount),
+            isEmbedded || signature.match(`^[0]+$`) ? undefined : signature,
+            signerPublicKey.match(`^[0]+$`) ? undefined : PublicAccount.createFromPublicKey(signerPublicKey, networkType),
         );
         return isEmbedded ? transaction.toAggregate(PublicAccount.createFromPublicKey(signerPublicKey, networkType)) : transaction;
     }
@@ -177,8 +186,8 @@ export class MosaicMetadataTransaction extends Transaction {
      * @returns {Uint8Array}
      */
     protected generateBytes(): Uint8Array {
-        const signerBuffer = new Uint8Array(32);
-        const signatureBuffer = new Uint8Array(64);
+        const signerBuffer = this.signer !== undefined ? Convert.hexToUint8(this.signer.publicKey) : new Uint8Array(32);
+        const signatureBuffer = this.signature !== undefined ? Convert.hexToUint8(this.signature) : new Uint8Array(64);
 
         const transactionBuilder = new MosaicMetadataTransactionBuilder(
             new SignatureDto(signatureBuffer),

--- a/src/model/transaction/MultisigAccountModificationTransaction.ts
+++ b/src/model/transaction/MultisigAccountModificationTransaction.ts
@@ -50,6 +50,8 @@ export class MultisigAccountModificationTransaction extends Transaction {
      * @param publicKeyDeletions - Cosignatory public key deletions.
      * @param networkType - The network type.
      * @param maxFee - (Optional) Max fee defined by the sender
+     * @param signature - (Optional) Transaction signature
+     * @param signer - (Optional) Signer public account
      * @returns {MultisigAccountModificationTransaction}
      */
     public static create(
@@ -60,6 +62,8 @@ export class MultisigAccountModificationTransaction extends Transaction {
         publicKeyDeletions: PublicAccount[],
         networkType: NetworkType,
         maxFee: UInt64 = new UInt64([0, 0]),
+        signature?: string,
+        signer?: PublicAccount,
     ): MultisigAccountModificationTransaction {
         return new MultisigAccountModificationTransaction(
             networkType,
@@ -70,6 +74,8 @@ export class MultisigAccountModificationTransaction extends Transaction {
             minRemovalDelta,
             publicKeyAdditions,
             publicKeyDeletions,
+            signature,
+            signer,
         );
     }
 
@@ -128,6 +134,7 @@ export class MultisigAccountModificationTransaction extends Transaction {
             : MultisigAccountModificationTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
         const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
         const networkType = builder.getNetwork().valueOf();
+        const signature = payload.substring(16, 144);
         const transaction = MultisigAccountModificationTransaction.create(
             isEmbedded
                 ? Deadline.create()
@@ -142,6 +149,8 @@ export class MultisigAccountModificationTransaction extends Transaction {
             }),
             networkType,
             isEmbedded ? new UInt64([0, 0]) : new UInt64((builder as MultisigAccountModificationTransactionBuilder).fee.amount),
+            isEmbedded || signature.match(`^[0]+$`) ? undefined : signature,
+            signerPublicKey.match(`^[0]+$`) ? undefined : PublicAccount.createFromPublicKey(signerPublicKey, networkType),
         );
         return isEmbedded ? transaction.toAggregate(PublicAccount.createFromPublicKey(signerPublicKey, networkType)) : transaction;
     }
@@ -181,8 +190,8 @@ export class MultisigAccountModificationTransaction extends Transaction {
      * @returns {Uint8Array}
      */
     protected generateBytes(): Uint8Array {
-        const signerBuffer = new Uint8Array(32);
-        const signatureBuffer = new Uint8Array(64);
+        const signerBuffer = this.signer !== undefined ? Convert.hexToUint8(this.signer.publicKey) : new Uint8Array(32);
+        const signatureBuffer = this.signature !== undefined ? Convert.hexToUint8(this.signature) : new Uint8Array(64);
 
         const transactionBuilder = new MultisigAccountModificationTransactionBuilder(
             new SignatureDto(signatureBuffer),

--- a/src/model/transaction/PersistentDelegationRequestTransaction.ts
+++ b/src/model/transaction/PersistentDelegationRequestTransaction.ts
@@ -20,6 +20,7 @@ import { NetworkType } from '../network/NetworkType';
 import { UInt64 } from '../UInt64';
 import { Deadline } from './Deadline';
 import { TransferTransaction } from './TransferTransaction';
+import { PublicAccount } from '../account/PublicAccount';
 
 export class PersistentDelegationRequestTransaction extends TransferTransaction {
     /**
@@ -30,6 +31,8 @@ export class PersistentDelegationRequestTransaction extends TransferTransaction 
      * @param recipientPublicKey - The recipient public key
      * @param networkType - The network type.
      * @param maxFee - (Optional) Max fee defined by the sender
+     * @param signature - (Optional) Transaction signature
+     * @param signer - (Optional) Signer public account
      * @returns {TransferTransaction}
      */
     public static createPersistentDelegationRequestTransaction(
@@ -38,8 +41,19 @@ export class PersistentDelegationRequestTransaction extends TransferTransaction 
         recipientPublicKey: string,
         networkType: NetworkType,
         maxFee: UInt64 = new UInt64([0, 0]),
+        signature?: string,
+        signer?: PublicAccount,
     ): PersistentDelegationRequestTransaction {
         const message = PersistentHarvestingDelegationMessage.create(delegatedPrivateKey, recipientPublicKey, networkType);
-        return super.create(deadline, Address.createFromPublicKey(recipientPublicKey, networkType), [], message, networkType, maxFee);
+        return super.create(
+            deadline,
+            Address.createFromPublicKey(recipientPublicKey, networkType),
+            [],
+            message,
+            networkType,
+            maxFee,
+            signature,
+            signer,
+        );
     }
 }

--- a/src/model/transaction/SecretLockTransaction.ts
+++ b/src/model/transaction/SecretLockTransaction.ts
@@ -57,7 +57,8 @@ export class SecretLockTransaction extends Transaction {
      * @param recipientAddress - The unresolved recipient address of the funds.
      * @param networkType - The network type.
      * @param maxFee - (Optional) Max fee defined by the sender
-     *
+     * @param signature - (Optional) Transaction signature
+     * @param signer - (Optional) Signer public account
      * @return a SecretLockTransaction instance
      */
     public static create(
@@ -69,6 +70,8 @@ export class SecretLockTransaction extends Transaction {
         recipientAddress: Address | NamespaceId,
         networkType: NetworkType,
         maxFee: UInt64 = new UInt64([0, 0]),
+        signature?: string,
+        signer?: PublicAccount,
     ): SecretLockTransaction {
         return new SecretLockTransaction(
             networkType,
@@ -80,6 +83,8 @@ export class SecretLockTransaction extends Transaction {
             hashAlgorithm,
             secret,
             recipientAddress,
+            signature,
+            signer,
         );
     }
 
@@ -144,6 +149,7 @@ export class SecretLockTransaction extends Transaction {
             : SecretLockTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
         const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
         const networkType = builder.getNetwork().valueOf();
+        const signature = payload.substring(16, 144);
         const transaction = SecretLockTransaction.create(
             isEmbedded ? Deadline.create() : Deadline.createFromDTO((builder as SecretLockTransactionBuilder).getDeadline().timestamp),
             new Mosaic(
@@ -156,6 +162,8 @@ export class SecretLockTransaction extends Transaction {
             UnresolvedMapping.toUnresolvedAddress(Convert.uint8ToHex(builder.getRecipientAddress().unresolvedAddress)),
             networkType,
             isEmbedded ? new UInt64([0, 0]) : new UInt64((builder as SecretLockTransactionBuilder).fee.amount),
+            isEmbedded || signature.match(`^[0]+$`) ? undefined : signature,
+            signerPublicKey.match(`^[0]+$`) ? undefined : PublicAccount.createFromPublicKey(signerPublicKey, networkType),
         );
         return isEmbedded ? transaction.toAggregate(PublicAccount.createFromPublicKey(signerPublicKey, networkType)) : transaction;
     }
@@ -196,8 +204,8 @@ export class SecretLockTransaction extends Transaction {
      * @returns {Uint8Array}
      */
     protected generateBytes(): Uint8Array {
-        const signerBuffer = new Uint8Array(32);
-        const signatureBuffer = new Uint8Array(64);
+        const signerBuffer = this.signer !== undefined ? Convert.hexToUint8(this.signer.publicKey) : new Uint8Array(32);
+        const signatureBuffer = this.signature !== undefined ? Convert.hexToUint8(this.signature) : new Uint8Array(64);
 
         const transactionBuilder = new SecretLockTransactionBuilder(
             new SignatureDto(signatureBuffer),

--- a/src/model/transaction/TransferTransaction.ts
+++ b/src/model/transaction/TransferTransaction.ts
@@ -64,6 +64,8 @@ export class TransferTransaction extends Transaction {
      * @param message - The transaction message.
      * @param networkType - The network type.
      * @param maxFee - (Optional) Max fee defined by the sender
+     * @param signature - (Optional) Transaction signature
+     * @param signer - (Optional) Signer public account
      * @returns {TransferTransaction}
      */
     public static create(
@@ -73,8 +75,20 @@ export class TransferTransaction extends Transaction {
         message: Message,
         networkType: NetworkType,
         maxFee: UInt64 = new UInt64([0, 0]),
+        signature?: string,
+        signer?: PublicAccount,
     ): TransferTransaction {
-        return new TransferTransaction(networkType, TransactionVersion.TRANSFER, deadline, maxFee, recipientAddress, mosaics, message);
+        return new TransferTransaction(
+            networkType,
+            TransactionVersion.TRANSFER,
+            deadline,
+            maxFee,
+            recipientAddress,
+            mosaics,
+            message,
+            signature,
+            signer,
+        );
     }
 
     /**
@@ -128,6 +142,7 @@ export class TransferTransaction extends Transaction {
         const messageHex = Convert.uint8ToHex(builder.getMessage()).substring(2);
         const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
         const networkType = builder.getNetwork().valueOf();
+        const signature = payload.substring(16, 144);
         const transaction = TransferTransaction.create(
             isEmbedded ? Deadline.create() : Deadline.createFromDTO((builder as TransferTransactionBuilder).getDeadline().timestamp),
             UnresolvedMapping.toUnresolvedAddress(Convert.uint8ToHex(builder.getRecipientAddress().unresolvedAddress)),
@@ -140,6 +155,8 @@ export class TransferTransaction extends Transaction {
                 : EncryptedMessage.createFromPayload(messageHex),
             networkType,
             isEmbedded ? new UInt64([0, 0]) : new UInt64((builder as TransferTransactionBuilder).fee.amount),
+            isEmbedded || signature.match(`^[0]+$`) ? undefined : signature,
+            signerPublicKey.match(`^[0]+$`) ? undefined : PublicAccount.createFromPublicKey(signerPublicKey, networkType),
         );
         return isEmbedded ? transaction.toAggregate(PublicAccount.createFromPublicKey(signerPublicKey, networkType)) : transaction;
     }
@@ -240,8 +257,8 @@ export class TransferTransaction extends Transaction {
      * @returns {Uint8Array}
      */
     protected generateBytes(): Uint8Array {
-        const signerBuffer = new Uint8Array(32);
-        const signatureBuffer = new Uint8Array(64);
+        const signerBuffer = this.signer !== undefined ? Convert.hexToUint8(this.signer.publicKey) : new Uint8Array(32);
+        const signatureBuffer = this.signature !== undefined ? Convert.hexToUint8(this.signature) : new Uint8Array(64);
 
         const transactionBuilder = new TransferTransactionBuilder(
             new SignatureDto(signatureBuffer),

--- a/src/model/transaction/VrfKeyLinkTransaction.ts
+++ b/src/model/transaction/VrfKeyLinkTransaction.ts
@@ -42,6 +42,8 @@ export class VrfKeyLinkTransaction extends Transaction {
      * @param linkedPublicKey - The public key of the remote account.
      * @param linkAction - The account link action.
      * @param maxFee - (Optional) Max fee defined by the sender
+     * @param signature - (Optional) Transaction signature
+     * @param signer - (Optional) Signer public account
      * @returns {VrfKeyLinkTransaction}
      */
     public static create(
@@ -50,8 +52,19 @@ export class VrfKeyLinkTransaction extends Transaction {
         linkAction: LinkAction,
         networkType: NetworkType,
         maxFee: UInt64 = new UInt64([0, 0]),
+        signature?: string,
+        signer?: PublicAccount,
     ): VrfKeyLinkTransaction {
-        return new VrfKeyLinkTransaction(networkType, TransactionVersion.VRF_KEY_LINK, deadline, maxFee, linkedPublicKey, linkAction);
+        return new VrfKeyLinkTransaction(
+            networkType,
+            TransactionVersion.VRF_KEY_LINK,
+            deadline,
+            maxFee,
+            linkedPublicKey,
+            linkAction,
+            signature,
+            signer,
+        );
     }
 
     /**
@@ -97,12 +110,15 @@ export class VrfKeyLinkTransaction extends Transaction {
             : VrfKeyLinkTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
         const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
         const networkType = builder.getNetwork().valueOf();
+        const signature = payload.substring(16, 144);
         const transaction = VrfKeyLinkTransaction.create(
             isEmbedded ? Deadline.create() : Deadline.createFromDTO((builder as VrfKeyLinkTransactionBuilder).getDeadline().timestamp),
             Convert.uint8ToHex(builder.getLinkedPublicKey().key),
             builder.getLinkAction().valueOf(),
             networkType,
             isEmbedded ? new UInt64([0, 0]) : new UInt64((builder as VrfKeyLinkTransactionBuilder).fee.amount),
+            isEmbedded || signature.match(`^[0]+$`) ? undefined : signature,
+            signerPublicKey.match(`^[0]+$`) ? undefined : PublicAccount.createFromPublicKey(signerPublicKey, networkType),
         );
         return isEmbedded ? transaction.toAggregate(PublicAccount.createFromPublicKey(signerPublicKey, networkType)) : transaction;
     }
@@ -128,8 +144,8 @@ export class VrfKeyLinkTransaction extends Transaction {
      * @returns {Uint8Array}
      */
     protected generateBytes(): Uint8Array {
-        const signerBuffer = new Uint8Array(32);
-        const signatureBuffer = new Uint8Array(64);
+        const signerBuffer = this.signer !== undefined ? Convert.hexToUint8(this.signer.publicKey) : new Uint8Array(32);
+        const signatureBuffer = this.signature !== undefined ? Convert.hexToUint8(this.signature) : new Uint8Array(64);
 
         const transactionBuilder = new VrfKeyLinkTransactionBuilder(
             new SignatureDto(signatureBuffer),

--- a/test/core/utils/TransactionMappingWithSignatures.spec.ts
+++ b/test/core/utils/TransactionMappingWithSignatures.spec.ts
@@ -1,0 +1,1075 @@
+/*
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { deepEqual } from 'assert';
+import { expect } from 'chai';
+import { sha3_256 } from 'js-sha3';
+import { Convert } from '../../../src/core/format';
+import { TransactionMapping } from '../../../src/core/utils/TransactionMapping';
+import { Account } from '../../../src/model/account/Account';
+import { Address } from '../../../src/model/account/Address';
+import { PublicAccount } from '../../../src/model/account/PublicAccount';
+import { PlainMessage } from '../../../src/model/message/PlainMessage';
+import { MosaicFlags } from '../../../src/model/mosaic/MosaicFlags';
+import { MosaicId } from '../../../src/model/mosaic/MosaicId';
+import { MosaicNonce } from '../../../src/model/mosaic/MosaicNonce';
+import { MosaicSupplyChangeAction } from '../../../src/model/mosaic/MosaicSupplyChangeAction';
+import { NetworkCurrencyLocal } from '../../../src/model/mosaic/NetworkCurrencyLocal';
+import { AliasAction } from '../../../src/model/namespace/AliasAction';
+import { NamespaceId } from '../../../src/model/namespace/NamespaceId';
+import { NamespaceRegistrationType } from '../../../src/model/namespace/NamespaceRegistrationType';
+import { NetworkType } from '../../../src/model/network/NetworkType';
+import { AccountRestrictionFlags } from '../../../src/model/restriction/AccountRestrictionType';
+import { MosaicRestrictionType } from '../../../src/model/restriction/MosaicRestrictionType';
+import { AccountAddressRestrictionTransaction } from '../../../src/model/transaction/AccountAddressRestrictionTransaction';
+import { AccountKeyLinkTransaction } from '../../../src/model/transaction/AccountKeyLinkTransaction';
+import { AccountMetadataTransaction } from '../../../src/model/transaction/AccountMetadataTransaction';
+import { AccountMosaicRestrictionTransaction } from '../../../src/model/transaction/AccountMosaicRestrictionTransaction';
+import { AccountOperationRestrictionTransaction } from '../../../src/model/transaction/AccountOperationRestrictionTransaction';
+import { AccountRestrictionTransaction } from '../../../src/model/transaction/AccountRestrictionTransaction';
+import { AddressAliasTransaction } from '../../../src/model/transaction/AddressAliasTransaction';
+import { AggregateTransaction } from '../../../src/model/transaction/AggregateTransaction';
+import { Deadline } from '../../../src/model/transaction/Deadline';
+import { LockHashAlgorithm } from '../../../src/model/transaction/LockHashAlgorithm';
+import { LinkAction } from '../../../src/model/transaction/LinkAction';
+import { LockFundsTransaction } from '../../../src/model/transaction/LockFundsTransaction';
+import { MosaicAddressRestrictionTransaction } from '../../../src/model/transaction/MosaicAddressRestrictionTransaction';
+import { MosaicAliasTransaction } from '../../../src/model/transaction/MosaicAliasTransaction';
+import { MosaicDefinitionTransaction } from '../../../src/model/transaction/MosaicDefinitionTransaction';
+import { MosaicGlobalRestrictionTransaction } from '../../../src/model/transaction/MosaicGlobalRestrictionTransaction';
+import { MosaicMetadataTransaction } from '../../../src/model/transaction/MosaicMetadataTransaction';
+import { MosaicSupplyChangeTransaction } from '../../../src/model/transaction/MosaicSupplyChangeTransaction';
+import { MultisigAccountModificationTransaction } from '../../../src/model/transaction/MultisigAccountModificationTransaction';
+import { NamespaceMetadataTransaction } from '../../../src/model/transaction/NamespaceMetadataTransaction';
+import { NamespaceRegistrationTransaction } from '../../../src/model/transaction/NamespaceRegistrationTransaction';
+import { SecretLockTransaction } from '../../../src/model/transaction/SecretLockTransaction';
+import { SecretProofTransaction } from '../../../src/model/transaction/SecretProofTransaction';
+import { TransactionType } from '../../../src/model/transaction/TransactionType';
+import { TransferTransaction } from '../../../src/model/transaction/TransferTransaction';
+import { UInt64 } from '../../../src/model/UInt64';
+import { TestingAccount } from '../../conf/conf.spec';
+import { VrfKeyLinkTransaction } from '../../../src/model/transaction/VrfKeyLinkTransaction';
+import { VotingKeyLinkTransaction } from '../../../src/model/transaction/VotingKeyLinkTransaction';
+import { Crypto } from '../../../src/core/crypto';
+import { NodeKeyLinkTransaction } from '../../../src/model/transaction/NodeKeyLinkTransaction';
+
+describe('TransactionMapping - createFromPayload with optional sigature and signer', () => {
+    let account: Account;
+    const emtptySignature = Convert.uint8ToHex(new Uint8Array(64));
+    const testSignature =
+        '4CBA582B4C898FD6D218499251FE8EE1214D3715545023123F70D25389D577A96E74C1FCD07FF8F0D678A4DA5CAD8CCB173DDD9F7975A6985ADCD7AD625B170F';
+    const generationHash = '57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6';
+    before(() => {
+        account = TestingAccount;
+    });
+
+    it('should create AccountRestrictionAddressTransaction', () => {
+        const address = Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
+        const addressRestrictionTransaction = AccountRestrictionTransaction.createAddressRestrictionModificationTransaction(
+            Deadline.create(),
+            AccountRestrictionFlags.AllowIncomingAddress,
+            [address],
+            [],
+            NetworkType.MIJIN_TEST,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+        let signedTransaction = addressRestrictionTransaction.serialize();
+
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as AccountAddressRestrictionTransaction;
+
+        expect(transaction.restrictionFlags).to.be.equal(AccountRestrictionFlags.AllowIncomingAddress);
+        expect((transaction.restrictionAdditions[0] as Address).plain()).to.be.equal('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
+        expect(transaction.restrictionDeletions.length).to.be.equal(0);
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(addressRestrictionTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = addressRestrictionTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as AccountAddressRestrictionTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create AccountRestrictionMosaicTransaction', () => {
+        const mosaicId = new MosaicId([2262289484, 3405110546]);
+        const mosaicRestrictionTransaction = AccountRestrictionTransaction.createMosaicRestrictionModificationTransaction(
+            Deadline.create(),
+            AccountRestrictionFlags.AllowMosaic,
+            [mosaicId],
+            [],
+            NetworkType.MIJIN_TEST,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = mosaicRestrictionTransaction.serialize();
+
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as AccountMosaicRestrictionTransaction;
+        expect(transaction.restrictionFlags).to.be.equal(AccountRestrictionFlags.AllowMosaic);
+        expect((transaction.restrictionAdditions[0] as MosaicId).toHex()).to.be.equal(mosaicId.toHex());
+        expect(transaction.restrictionDeletions.length).to.be.equal(0);
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(mosaicRestrictionTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = mosaicRestrictionTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as AccountMosaicRestrictionTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create AccountRestrictionOperationTransaction', () => {
+        const operation = TransactionType.ADDRESS_ALIAS;
+        const operationRestrictionTransaction = AccountRestrictionTransaction.createOperationRestrictionModificationTransaction(
+            Deadline.create(),
+            AccountRestrictionFlags.AllowOutgoingTransactionType,
+            [operation],
+            [],
+            NetworkType.MIJIN_TEST,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = operationRestrictionTransaction.serialize();
+
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as AccountOperationRestrictionTransaction;
+        expect(transaction.restrictionFlags).to.be.equal(AccountRestrictionFlags.AllowOutgoingTransactionType);
+        expect(transaction.restrictionAdditions[0]).to.be.equal(operation);
+        expect(transaction.restrictionDeletions.length).to.be.equal(0);
+
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(operationRestrictionTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = operationRestrictionTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as AccountOperationRestrictionTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create AddressAliasTransaction', () => {
+        const namespaceId = new NamespaceId([33347626, 3779697293]);
+        const address = Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
+        const addressAliasTransaction = AddressAliasTransaction.create(
+            Deadline.create(),
+            AliasAction.Link,
+            namespaceId,
+            address,
+            NetworkType.MIJIN_TEST,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = addressAliasTransaction.serialize();
+
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as AddressAliasTransaction;
+
+        expect(transaction.aliasAction).to.be.equal(AliasAction.Link);
+        expect(transaction.namespaceId.id.lower).to.be.equal(33347626);
+        expect(transaction.namespaceId.id.higher).to.be.equal(3779697293);
+        expect(transaction.address.plain()).to.be.equal('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(addressAliasTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = addressAliasTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as AddressAliasTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create MosaicAliasTransaction', () => {
+        const namespaceId = new NamespaceId([33347626, 3779697293]);
+        const mosaicId = new MosaicId([2262289484, 3405110546]);
+        const mosaicAliasTransaction = MosaicAliasTransaction.create(
+            Deadline.create(),
+            AliasAction.Link,
+            namespaceId,
+            mosaicId,
+            NetworkType.MIJIN_TEST,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = mosaicAliasTransaction.serialize();
+
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as MosaicAliasTransaction;
+        expect(transaction.aliasAction).to.be.equal(AliasAction.Link);
+        expect(transaction.namespaceId.id.lower).to.be.equal(33347626);
+        expect(transaction.namespaceId.id.higher).to.be.equal(3779697293);
+        expect(transaction.mosaicId.id.lower).to.be.equal(2262289484);
+        expect(transaction.mosaicId.id.higher).to.be.equal(3405110546);
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(mosaicAliasTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = mosaicAliasTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as MosaicAliasTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create MosaicDefinitionTransaction', () => {
+        const mosaicDefinitionTransaction = MosaicDefinitionTransaction.create(
+            Deadline.create(),
+            MosaicNonce.createFromUint8Array(new Uint8Array([0xe6, 0xde, 0x84, 0xb8])), // nonce
+            new MosaicId(UInt64.fromUint(1).toDTO()), // ID
+            MosaicFlags.create(false, false, false),
+            3,
+            UInt64.fromUint(1000),
+            NetworkType.MIJIN_TEST,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = mosaicDefinitionTransaction.serialize();
+
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as MosaicDefinitionTransaction;
+
+        expect(transaction.duration!.lower).to.be.equal(1000);
+        expect(transaction.duration!.higher).to.be.equal(0);
+        expect(transaction.divisibility).to.be.equal(3);
+        expect(transaction.flags.supplyMutable).to.be.equal(false);
+        expect(transaction.flags.transferable).to.be.equal(false);
+        expect(transaction.flags.restrictable).to.be.equal(false);
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(mosaicDefinitionTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = mosaicDefinitionTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as MosaicDefinitionTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create MosaicDefinitionTransaction - without duration', () => {
+        const mosaicDefinitionTransaction = MosaicDefinitionTransaction.create(
+            Deadline.create(),
+            MosaicNonce.createFromUint8Array(new Uint8Array([0xe6, 0xde, 0x84, 0xb8])), // nonce
+            new MosaicId(UInt64.fromUint(1).toDTO()), // ID
+            MosaicFlags.create(false, false, false),
+            3,
+            UInt64.fromUint(0),
+            NetworkType.MIJIN_TEST,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = mosaicDefinitionTransaction.serialize();
+
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as MosaicDefinitionTransaction;
+
+        expect(transaction.divisibility).to.be.equal(3);
+        expect(transaction.flags.supplyMutable).to.be.equal(false);
+        expect(transaction.flags.transferable).to.be.equal(false);
+        expect(transaction.flags.restrictable).to.be.equal(false);
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(mosaicDefinitionTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = mosaicDefinitionTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as MosaicDefinitionTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create MosaicSupplyChangeTransaction', () => {
+        const mosaicId = new MosaicId([2262289484, 3405110546]);
+        const mosaicSupplyChangeTransaction = MosaicSupplyChangeTransaction.create(
+            Deadline.create(),
+            mosaicId,
+            MosaicSupplyChangeAction.Increase,
+            UInt64.fromUint(10),
+            NetworkType.MIJIN_TEST,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = mosaicSupplyChangeTransaction.serialize();
+
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as MosaicSupplyChangeTransaction;
+
+        expect(transaction.action).to.be.equal(MosaicSupplyChangeAction.Increase);
+        expect(transaction.delta.lower).to.be.equal(10);
+        expect(transaction.delta.higher).to.be.equal(0);
+        expect(transaction.mosaicId.id.lower).to.be.equal(2262289484);
+        expect(transaction.mosaicId.id.higher).to.be.equal(3405110546);
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(mosaicSupplyChangeTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = mosaicSupplyChangeTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as MosaicSupplyChangeTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create TransferTransaction', () => {
+        const transferTransaction = TransferTransaction.create(
+            Deadline.create(),
+            Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC'),
+            [NetworkCurrencyLocal.createRelative(100)],
+            PlainMessage.create('test-message'),
+            NetworkType.MIJIN_TEST,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = transferTransaction.serialize();
+
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as TransferTransaction;
+
+        expect(transaction.message.payload).to.be.equal('test-message');
+        expect(transaction.mosaics.length).to.be.equal(1);
+        expect(transaction.recipientToString()).to.be.equal('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(transferTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = transferTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as TransferTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create SecretLockTransaction', () => {
+        const proof = 'B778A39A3663719DFC5E48C9D78431B1E45C2AF9DF538782BF199C189DABEAC7';
+        const recipientAddress = Address.createFromRawAddress('SDBDG4IT43MPCW2W4CBBCSJJT42AYALQN7A4VVWL');
+        const secretLockTransaction = SecretLockTransaction.create(
+            Deadline.create(),
+            NetworkCurrencyLocal.createAbsolute(10),
+            UInt64.fromUint(100),
+            LockHashAlgorithm.Op_Sha3_256,
+            sha3_256.create().update(Convert.hexToUint8(proof)).hex(),
+            recipientAddress,
+            NetworkType.MIJIN_TEST,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = secretLockTransaction.serialize();
+
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as SecretLockTransaction;
+
+        expect(transaction.mosaic.amount.equals(UInt64.fromUint(10))).to.be.equal(true);
+        expect(transaction.duration.equals(UInt64.fromUint(100))).to.be.equal(true);
+        expect(transaction.hashAlgorithm).to.be.equal(0);
+        expect(transaction.secret).to.be.equal('9B3155B37159DA50AA52D5967C509B410F5A36A3B1E31ECB5AC76675D79B4A5E');
+        expect((transaction.recipientAddress as Address).plain()).to.be.equal(recipientAddress.plain());
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(secretLockTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = secretLockTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as SecretLockTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create SecretProofTransaction', () => {
+        const proof = 'B778A39A3663719DFC5E48C9D78431B1E45C2AF9DF538782BF199C189DABEAC7';
+        const secretProofTransaction = SecretProofTransaction.create(
+            Deadline.create(),
+            LockHashAlgorithm.Op_Sha3_256,
+            sha3_256.create().update(Convert.hexToUint8(proof)).hex(),
+            account.address,
+            proof,
+            NetworkType.MIJIN_TEST,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = secretProofTransaction.serialize();
+
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as SecretProofTransaction;
+        expect(transaction.hashAlgorithm).to.be.equal(0);
+        expect(transaction.secret).to.be.equal('9B3155B37159DA50AA52D5967C509B410F5A36A3B1E31ECB5AC76675D79B4A5E');
+        expect(transaction.proof).to.be.equal(proof);
+        expect((transaction.recipientAddress as Address).plain()).to.be.equal(account.address.plain());
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(secretProofTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = secretProofTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as SecretProofTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create ModifyMultiSigTransaction', () => {
+        const modifyMultisigAccountTransaction = MultisigAccountModificationTransaction.create(
+            Deadline.create(),
+            2,
+            1,
+            [PublicAccount.createFromPublicKey('B0F93CBEE49EEB9953C6F3985B15A4F238E205584D8F924C621CBE4D7AC6EC24', NetworkType.MIJIN_TEST)],
+            [],
+            NetworkType.MIJIN_TEST,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = modifyMultisigAccountTransaction.serialize();
+
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as MultisigAccountModificationTransaction;
+
+        expect(transaction.minApprovalDelta).to.be.equal(2);
+        expect(transaction.minRemovalDelta).to.be.equal(1);
+        expect(transaction.publicKeyAdditions[0].publicKey).to.be.equal('B0F93CBEE49EEB9953C6F3985B15A4F238E205584D8F924C621CBE4D7AC6EC24');
+        expect(transaction.publicKeyDeletions.length).to.be.equal(0);
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(modifyMultisigAccountTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = modifyMultisigAccountTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as MultisigAccountModificationTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create AggregatedTransaction - Complete', () => {
+        const transferTransaction = TransferTransaction.create(
+            Deadline.create(),
+            Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC'),
+            [],
+            PlainMessage.create('test-message'),
+            NetworkType.MIJIN_TEST,
+        );
+
+        const accountLinkTransaction = AccountKeyLinkTransaction.create(
+            Deadline.create(),
+            account.publicKey,
+            LinkAction.Link,
+            NetworkType.MIJIN_TEST,
+        );
+        const vrfKeyLinkTransaction = VrfKeyLinkTransaction.create(
+            Deadline.create(),
+            account.publicKey,
+            LinkAction.Link,
+            NetworkType.MIJIN_TEST,
+        );
+        const nodeKeyLinkTransaction = NodeKeyLinkTransaction.create(
+            Deadline.create(),
+            account.publicKey,
+            LinkAction.Link,
+            NetworkType.MIJIN_TEST,
+        );
+        const votingKeyLinkTransaction = VotingKeyLinkTransaction.create(
+            Deadline.create(),
+            Convert.uint8ToHex(Crypto.randomBytes(48)),
+            LinkAction.Link,
+            NetworkType.MIJIN_TEST,
+        );
+        const registerNamespaceTransaction = NamespaceRegistrationTransaction.createRootNamespace(
+            Deadline.create(),
+            'root-test-namespace',
+            UInt64.fromUint(1000),
+            NetworkType.MIJIN_TEST,
+        );
+        const mosaicGlobalRestrictionTransaction = MosaicGlobalRestrictionTransaction.create(
+            Deadline.create(),
+            new MosaicId(UInt64.fromUint(1).toDTO()),
+            UInt64.fromUint(4444),
+            UInt64.fromUint(0),
+            MosaicRestrictionType.NONE,
+            UInt64.fromUint(0),
+            MosaicRestrictionType.GE,
+            NetworkType.MIJIN_TEST,
+        );
+        const mosaicAddressRestrictionTransaction = MosaicAddressRestrictionTransaction.create(
+            Deadline.create(),
+            new NamespaceId('test'),
+            UInt64.fromUint(4444),
+            account.address,
+            UInt64.fromUint(0),
+            NetworkType.MIJIN_TEST,
+            UInt64.fromUint(0),
+        );
+        const accountMetadataTransaction = AccountMetadataTransaction.create(
+            Deadline.create(),
+            account.publicKey,
+            UInt64.fromUint(1000),
+            1,
+            Convert.uint8ToUtf8(new Uint8Array(10)),
+            NetworkType.MIJIN_TEST,
+        );
+        const mosaicMetadataTransaction = MosaicMetadataTransaction.create(
+            Deadline.create(),
+            account.publicKey,
+            UInt64.fromUint(1000),
+            new MosaicId([2262289484, 3405110546]),
+            1,
+            Convert.uint8ToUtf8(new Uint8Array(10)),
+            NetworkType.MIJIN_TEST,
+        );
+        const namespaceMetadataTransaction = NamespaceMetadataTransaction.create(
+            Deadline.create(),
+            account.publicKey,
+            UInt64.fromUint(1000),
+            new NamespaceId([2262289484, 3405110546]),
+            1,
+            Convert.uint8ToUtf8(new Uint8Array(10)),
+            NetworkType.MIJIN_TEST,
+        );
+
+        const mosaicAliasTransaction = MosaicAliasTransaction.create(
+            Deadline.create(),
+            AliasAction.Link,
+            new NamespaceId([2262289484, 3405110546]),
+            new MosaicId([2262289484, 3405110546]),
+            NetworkType.MIJIN_TEST,
+        );
+
+        const secretProofTransaction = SecretProofTransaction.create(
+            Deadline.create(),
+            LockHashAlgorithm.Op_Sha3_256,
+            sha3_256.create().update(Convert.hexToUint8('B778A39A3663719DFC5E48C9D78431B1E45C2AF9DF538782BF199C189DABEAC7')).hex(),
+            account.address,
+            'B778A39A3663719DFC5E48C9D78431B1E45C2AF9DF538782BF199C189DABEAC7',
+            NetworkType.MIJIN_TEST,
+        );
+
+        const aggregateTransaction = AggregateTransaction.createComplete(
+            Deadline.create(),
+            [
+                transferTransaction.toAggregate(account.publicAccount),
+                accountLinkTransaction.toAggregate(account.publicAccount),
+                vrfKeyLinkTransaction.toAggregate(account.publicAccount),
+                nodeKeyLinkTransaction.toAggregate(account.publicAccount),
+                votingKeyLinkTransaction.toAggregate(account.publicAccount),
+                registerNamespaceTransaction.toAggregate(account.publicAccount),
+                mosaicGlobalRestrictionTransaction.toAggregate(account.publicAccount),
+                mosaicAddressRestrictionTransaction.toAggregate(account.publicAccount),
+                mosaicMetadataTransaction.toAggregate(account.publicAccount),
+                namespaceMetadataTransaction.toAggregate(account.publicAccount),
+                accountMetadataTransaction.toAggregate(account.publicAccount),
+                mosaicAliasTransaction.toAggregate(account.publicAccount),
+                secretProofTransaction.toAggregate(account.publicAccount),
+            ],
+            NetworkType.MIJIN_TEST,
+            [],
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = aggregateTransaction.serialize();
+
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as AggregateTransaction;
+
+        expect(transaction.type).to.be.equal(TransactionType.AGGREGATE_COMPLETE);
+        expect(transaction.innerTransactions[0].type).to.be.equal(TransactionType.TRANSFER);
+        expect(transaction.innerTransactions.length).to.be.greaterThan(0);
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(aggregateTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = aggregateTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as AggregateTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create AggregatedTransaction - Bonded', () => {
+        const transferTransaction = TransferTransaction.create(
+            Deadline.create(),
+            Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC'),
+            [],
+            PlainMessage.create('test-message'),
+            NetworkType.MIJIN_TEST,
+        );
+
+        const aggregateTransaction = AggregateTransaction.createBonded(
+            Deadline.create(),
+            [transferTransaction.toAggregate(account.publicAccount)],
+            NetworkType.MIJIN_TEST,
+            [],
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = aggregateTransaction.serialize();
+
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as AggregateTransaction;
+
+        expect(transaction.type).to.be.equal(TransactionType.AGGREGATE_BONDED);
+        expect(transaction.innerTransactions[0].type).to.be.equal(TransactionType.TRANSFER);
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(aggregateTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = aggregateTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as AggregateTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create LockFundTransaction', () => {
+        const aggregateTransaction = AggregateTransaction.createBonded(Deadline.create(), [], NetworkType.MIJIN_TEST, []);
+        const signedTransaction = account.sign(aggregateTransaction, generationHash);
+        const lockTransaction = LockFundsTransaction.create(
+            Deadline.create(),
+            NetworkCurrencyLocal.createRelative(10),
+            UInt64.fromUint(10),
+            signedTransaction,
+            NetworkType.MIJIN_TEST,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedLockFundTransaction = lockTransaction.serialize();
+
+        let transaction = TransactionMapping.createFromPayload(signedLockFundTransaction) as LockFundsTransaction;
+
+        deepEqual(transaction.mosaic.id.id, NetworkCurrencyLocal.NAMESPACE_ID.id);
+        expect(transaction.mosaic.amount.compact()).to.be.equal(10000000);
+        expect(transaction.hash).to.be.equal(signedTransaction.hash);
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(aggregateTransaction, { signature: emtptySignature, signer: undefined });
+        signedLockFundTransaction = aggregateTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedLockFundTransaction) as LockFundsTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create an AccountKeyLinkTransaction object with link action', () => {
+        const accountLinkTransaction = AccountKeyLinkTransaction.create(
+            Deadline.create(),
+            account.publicKey,
+            LinkAction.Link,
+            NetworkType.MIJIN_TEST,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = accountLinkTransaction.serialize();
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as AccountKeyLinkTransaction;
+
+        expect(transaction.linkAction).to.be.equal(1);
+        expect(transaction.remotePublicKey).to.be.equal(account.publicKey);
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(accountLinkTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = accountLinkTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as AccountKeyLinkTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create an VrfKeyLinkTransaction object with link action', () => {
+        const vrfKeyLinkTransaction = VrfKeyLinkTransaction.create(
+            Deadline.create(),
+            account.publicKey,
+            LinkAction.Link,
+            NetworkType.MIJIN_TEST,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = vrfKeyLinkTransaction.serialize();
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as VrfKeyLinkTransaction;
+
+        expect(transaction.linkAction).to.be.equal(1);
+        expect(transaction.linkedPublicKey).to.be.equal(account.publicKey);
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(vrfKeyLinkTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = vrfKeyLinkTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as VrfKeyLinkTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create an NodeKeyLinkTransaction object with link action', () => {
+        const nodeKeyLinkTransaction = NodeKeyLinkTransaction.create(
+            Deadline.create(),
+            account.publicKey,
+            LinkAction.Link,
+            NetworkType.MIJIN_TEST,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = nodeKeyLinkTransaction.serialize();
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as NodeKeyLinkTransaction;
+
+        expect(transaction.linkAction).to.be.equal(1);
+        expect(transaction.linkedPublicKey).to.be.equal(account.publicKey);
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(nodeKeyLinkTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = nodeKeyLinkTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as NodeKeyLinkTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create an VotingKeyLinkTransaction object with link action', () => {
+        const key = Convert.uint8ToHex(Crypto.randomBytes(48));
+        const votingKeyLinkTransaction = VotingKeyLinkTransaction.create(
+            Deadline.create(),
+            key,
+            LinkAction.Link,
+            NetworkType.MIJIN_TEST,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = votingKeyLinkTransaction.serialize();
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as VotingKeyLinkTransaction;
+
+        expect(transaction.linkAction).to.be.equal(1);
+        expect(transaction.linkedPublicKey).to.be.equal(key);
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(votingKeyLinkTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = votingKeyLinkTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as VotingKeyLinkTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create NamespaceRegistrationTransaction - Root', () => {
+        const registerNamespaceTransaction = NamespaceRegistrationTransaction.createRootNamespace(
+            Deadline.create(),
+            'root-test-namespace',
+            UInt64.fromUint(1000),
+            NetworkType.MIJIN_TEST,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = registerNamespaceTransaction.serialize();
+
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as NamespaceRegistrationTransaction;
+
+        expect(transaction.registrationType).to.be.equal(NamespaceRegistrationType.RootNamespace);
+        expect(transaction.namespaceName).to.be.equal('root-test-namespace');
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(registerNamespaceTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = registerNamespaceTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as NamespaceRegistrationTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create NamespaceRegistrationTransaction - Sub', () => {
+        const registerNamespaceTransaction = NamespaceRegistrationTransaction.createSubNamespace(
+            Deadline.create(),
+            'root-test-namespace',
+            'parent-test-namespace',
+            NetworkType.MIJIN_TEST,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = registerNamespaceTransaction.serialize();
+
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as NamespaceRegistrationTransaction;
+
+        expect(transaction.registrationType).to.be.equal(NamespaceRegistrationType.SubNamespace);
+        expect(transaction.namespaceName).to.be.equal('root-test-namespace');
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(registerNamespaceTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = registerNamespaceTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as NamespaceRegistrationTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create MosaicGlobalRestrictionTransaction', () => {
+        const mosaicGlobalRestrictionTransaction = MosaicGlobalRestrictionTransaction.create(
+            Deadline.create(),
+            new MosaicId(UInt64.fromUint(1).toDTO()),
+            UInt64.fromUint(4444),
+            UInt64.fromUint(0),
+            MosaicRestrictionType.NONE,
+            UInt64.fromUint(0),
+            MosaicRestrictionType.GE,
+            NetworkType.MIJIN_TEST,
+            undefined,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = mosaicGlobalRestrictionTransaction.serialize();
+
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as MosaicGlobalRestrictionTransaction;
+
+        expect(transaction.type).to.be.equal(TransactionType.MOSAIC_GLOBAL_RESTRICTION);
+        expect(transaction.mosaicId.toHex()).to.be.equal(new MosaicId(UInt64.fromUint(1).toDTO()).toHex());
+        expect(transaction.referenceMosaicId.toHex()).to.be.equal(new MosaicId(UInt64.fromUint(0).toDTO()).toHex());
+        expect(transaction.restrictionKey.toHex()).to.be.equal(UInt64.fromUint(4444).toHex());
+        expect(transaction.previousRestrictionValue.toHex()).to.be.equal(UInt64.fromUint(0).toHex());
+        expect(transaction.previousRestrictionType).to.be.equal(MosaicRestrictionType.NONE);
+        expect(transaction.newRestrictionValue.toHex()).to.be.equal(UInt64.fromUint(0).toHex());
+        expect(transaction.newRestrictionType).to.be.equal(MosaicRestrictionType.GE);
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(mosaicGlobalRestrictionTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = mosaicGlobalRestrictionTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as MosaicGlobalRestrictionTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create MosaicAddressRestrictionTransaction', () => {
+        const mosaicAddressRestrictionTransaction = MosaicAddressRestrictionTransaction.create(
+            Deadline.create(),
+            new MosaicId(UInt64.fromUint(1).toDTO()),
+            UInt64.fromUint(4444),
+            account.address,
+            UInt64.fromUint(0),
+            NetworkType.MIJIN_TEST,
+            UInt64.fromUint(0),
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = mosaicAddressRestrictionTransaction.serialize();
+
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as MosaicAddressRestrictionTransaction;
+
+        expect(transaction.type).to.be.equal(TransactionType.MOSAIC_ADDRESS_RESTRICTION);
+        expect(transaction.mosaicId.toHex()).to.be.equal(new MosaicId(UInt64.fromUint(1).toDTO()).toHex());
+        expect(transaction.restrictionKey.toHex()).to.be.equal(UInt64.fromUint(4444).toHex());
+        expect(transaction.targetAddressToString()).to.be.equal(account.address.plain());
+        expect(transaction.previousRestrictionValue.toHex()).to.be.equal(UInt64.fromUint(0).toHex());
+        expect(transaction.newRestrictionValue.toHex()).to.be.equal(UInt64.fromUint(0).toHex());
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(mosaicAddressRestrictionTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = mosaicAddressRestrictionTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as MosaicAddressRestrictionTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create MosaicAddressRestrictionTransaction - MosaicAlias', () => {
+        const mosaicAddressRestrictionTransaction = MosaicAddressRestrictionTransaction.create(
+            Deadline.create(),
+            new NamespaceId('test'),
+            UInt64.fromUint(4444),
+            account.address,
+            UInt64.fromUint(0),
+            NetworkType.MIJIN_TEST,
+            UInt64.fromUint(0),
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = mosaicAddressRestrictionTransaction.serialize();
+
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as MosaicAddressRestrictionTransaction;
+
+        expect(transaction.type).to.be.equal(TransactionType.MOSAIC_ADDRESS_RESTRICTION);
+        expect(transaction.mosaicId.toHex()).to.be.equal(new NamespaceId('test').toHex());
+        expect(transaction.mosaicId instanceof NamespaceId).to.be.true;
+        expect(transaction.restrictionKey.toHex()).to.be.equal(UInt64.fromUint(4444).toHex());
+        expect(transaction.targetAddressToString()).to.be.equal(account.address.plain());
+        expect(transaction.previousRestrictionValue.toHex()).to.be.equal(UInt64.fromUint(0).toHex());
+        expect(transaction.newRestrictionValue.toHex()).to.be.equal(UInt64.fromUint(0).toHex());
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(mosaicAddressRestrictionTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = mosaicAddressRestrictionTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as MosaicAddressRestrictionTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create AddressMetadataTransaction', () => {
+        const accountMetadataTransaction = AccountMetadataTransaction.create(
+            Deadline.create(),
+            account.publicKey,
+            UInt64.fromUint(1000),
+            1,
+            Convert.uint8ToUtf8(new Uint8Array(10)),
+            NetworkType.MIJIN_TEST,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+        let signedTransaction = accountMetadataTransaction.serialize();
+
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as AccountMetadataTransaction;
+
+        expect(transaction.type).to.be.equal(TransactionType.ACCOUNT_METADATA);
+        expect(transaction.targetPublicKey).to.be.equal(account.publicKey);
+        expect(transaction.scopedMetadataKey.toHex()).to.be.equal(UInt64.fromUint(1000).toHex());
+        expect(transaction.valueSizeDelta).to.be.equal(1);
+        expect(Convert.uint8ToHex(transaction.value)).to.be.equal(Convert.uint8ToHex(new Uint8Array(10)));
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(accountMetadataTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = accountMetadataTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as AccountMetadataTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create MosaicMetadataTransaction', () => {
+        const mosaicMetadataTransaction = MosaicMetadataTransaction.create(
+            Deadline.create(),
+            account.publicKey,
+            UInt64.fromUint(1000),
+            new MosaicId([2262289484, 3405110546]),
+            1,
+            Convert.uint8ToUtf8(new Uint8Array(10)),
+            NetworkType.MIJIN_TEST,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = mosaicMetadataTransaction.serialize();
+
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as MosaicMetadataTransaction;
+
+        expect(transaction.type).to.be.equal(TransactionType.MOSAIC_METADATA);
+        expect(transaction.targetPublicKey).to.be.equal(account.publicKey);
+        expect(transaction.scopedMetadataKey.toHex()).to.be.equal(UInt64.fromUint(1000).toHex());
+        expect(transaction.valueSizeDelta).to.be.equal(1);
+        expect(transaction.targetMosaicId.toHex()).to.be.equal(new MosaicId([2262289484, 3405110546]).toHex());
+        expect(Convert.uint8ToHex(transaction.value)).to.be.equal(Convert.uint8ToHex(new Uint8Array(10)));
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(mosaicMetadataTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = mosaicMetadataTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as MosaicMetadataTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should create NamespaceMetadataTransaction', () => {
+        const namespaceMetadataTransaction = NamespaceMetadataTransaction.create(
+            Deadline.create(),
+            account.publicKey,
+            UInt64.fromUint(1000),
+            new NamespaceId([2262289484, 3405110546]),
+            1,
+            Convert.uint8ToUtf8(new Uint8Array(10)),
+            NetworkType.MIJIN_TEST,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        let signedTransaction = namespaceMetadataTransaction.serialize();
+
+        let transaction = TransactionMapping.createFromPayload(signedTransaction) as NamespaceMetadataTransaction;
+
+        expect(transaction.type).to.be.equal(TransactionType.NAMESPACE_METADATA);
+        expect(transaction.targetPublicKey).to.be.equal(account.publicKey);
+        expect(transaction.scopedMetadataKey.toHex()).to.be.equal(UInt64.fromUint(1000).toHex());
+        expect(transaction.valueSizeDelta).to.be.equal(1);
+        expect(transaction.targetNamespaceId.toHex()).to.be.equal(new NamespaceId([2262289484, 3405110546]).toHex());
+        expect(Convert.uint8ToHex(transaction.value)).to.be.equal(Convert.uint8ToHex(new Uint8Array(10)));
+        expect(transaction.signature).to.be.equal(testSignature);
+        expect(transaction.signer?.publicKey).to.be.equal(account.publicKey);
+
+        Object.assign(namespaceMetadataTransaction, { signature: emtptySignature, signer: undefined });
+        signedTransaction = namespaceMetadataTransaction.serialize();
+
+        transaction = TransactionMapping.createFromPayload(signedTransaction) as NamespaceMetadataTransaction;
+        expect(transaction.signature).to.be.undefined;
+        expect(transaction.signer).to.be.undefined;
+    });
+
+    it('should throw error with invalid type', () => {
+        const transferTransaction = TransferTransaction.create(
+            Deadline.create(),
+            Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC'),
+            [NetworkCurrencyLocal.createRelative(100)],
+            PlainMessage.create('test-message'),
+            NetworkType.MIJIN_TEST,
+            undefined,
+            testSignature,
+            account.publicAccount,
+        );
+
+        const signedTransaction = transferTransaction.serialize();
+        const wrongType = signedTransaction.substring(0, 219) + '0000' + signedTransaction.substring(224);
+
+        expect(() => {
+            TransactionMapping.createFromPayload(wrongType) as TransferTransaction;
+        }).to.throw();
+    });
+});


### PR DESCRIPTION
#### Issue
When calling `Transaction.serialize()` which does not serialize signer and signature even both are not undefined. 

#### Fixed
- Added signature and signer to `Transaction.create...` and `Transaction.serialize`
- Added signature and signer to loadFromPayload.

Fixed #571