### PR TITLE
0.20.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.20.5] - 30-Jun-2020
+
+**Milestone**: Gorilla.1(0.9.6.2)
+ Package  | Version  | Link
+---|---|---
+SDK Core| v0.20.5 | [symbol-sdk](https://www.npmjs.com/package/symbol-sdk)
+Catbuffer | v0.0.21 | [catbuffer-typescript](https://www.npmjs.com/package/catbuffer-typescript)
+Client Library | v0.9.4  | [symbol-openapi-typescript-fetch-client](https://www.npmjs.com/package/symbol-openapi-typescript-fetch-client)
+
+- Added `maxVotingKeysPerAccount`, `minVotingKeyLifetime` and `maxVotingKeyLifetime` in **ChainProperties**.
+- Updated fetch client version to `0.9.4`.
+
 ## [0.20.4] - 29-Jun-2020
 
 **Milestone**: Gorilla.1(0.9.6.2)
@@ -602,6 +614,7 @@ Client Library | v0.7.20-alpha.6  | [nem2-sdk-openapi-typescript-node-client](ht
 
 - Initial code release.
 
+[0.20.5]: https://github.com/nemtech/symbol-sdk-typescript-javascript/compare/v0.20.4...v0.20.5
 [0.20.4]: https://github.com/nemtech/symbol-sdk-typescript-javascript/compare/v0.20.3...v0.20.4
 [0.20.3]: https://github.com/nemtech/symbol-sdk-typescript-javascript/compare/v0.20.2...v0.20.3
 [0.20.2]: https://github.com/nemtech/symbol-sdk-typescript-javascript/compare/v0.20.0...v0.20.2

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ The Symbol SDK for TypeScript / JavaScript allows you to develop web, mobile, an
 
 ### _Gorilla.1_ Network Compatibility (catapult-server@0.9.6.2)
 
-Due to a network upgrade with [catapult-server@Gorilla](https://github.com/nemtech/catapult-server/releases/tag/v0.9.6.2) version, **it is recommended to use this package's 0.20.4 version and upwards to use this package with Fushicho versioned networks**.
+Due to a network upgrade with [catapult-server@Gorilla](https://github.com/nemtech/catapult-server/releases/tag/v0.9.6.2) version, **it is recommended to use this package's 0.20.5 version and upwards to use this package with Fushicho versioned networks**.
 
-The upgrade to this package's [version v0.20.4](https://github.com/nemtech/symbol-sdk-typescript-javascript/releases/tag/v0.20.4) is mandatory for **_Gorilla compatibility**.
+The upgrade to this package's [version v0.20.5](https://github.com/nemtech/symbol-sdk-typescript-javascript/releases/tag/v0.20.5) is mandatory for **_Gorilla compatibility**.
 
 Find the complete release notes [here](CHANGELOG.md).
 


### PR DESCRIPTION
## [0.20.5] - 30-Jun-2020

**Milestone**: Gorilla.1(0.9.6.2)
 Package  | Version  | Link
---|---|---
SDK Core| v0.20.5 | [symbol-sdk](https://www.npmjs.com/package/symbol-sdk)
Catbuffer | v0.0.21 | [catbuffer-typescript](https://www.npmjs.com/package/catbuffer-typescript)
Client Library | v0.9.4  | [symbol-openapi-typescript-fetch-client](https://www.npmjs.com/package/symbol-openapi-typescript-fetch-client)

- Added `maxVotingKeysPerAccount`, `minVotingKeyLifetime` and `maxVotingKeyLifetime` in **ChainProperties**.
- Updated fetch client version to `0.9.4`.