### PR TITLE
Updated delegated harvesting message payload.

### DIFF
--- a/e2e/infrastructure/MetadataHttp.spec.ts
+++ b/e2e/infrastructure/MetadataHttp.spec.ts
@@ -130,6 +130,30 @@ describe('MetadataHttp', () => {
         });
     });
 
+    describe('AccountMetadataTransaction', () => {
+        it('aggregate', () => {
+            const accountMetadataTransaction = AccountMetadataTransaction.create(
+                Deadline.create(),
+                account.address,
+                UInt64.fromUint(6),
+                0,
+                `Test account mett value`,
+                networkType,
+                helper.maxFee,
+            );
+
+            const aggregateTransaction = AggregateTransaction.createComplete(
+                Deadline.create(),
+                [accountMetadataTransaction.toAggregate(account.publicAccount)],
+                networkType,
+                [],
+                helper.maxFee,
+            );
+            const signedTransaction = aggregateTransaction.signWith(account, generationHash);
+            return helper.announce(signedTransaction);
+        });
+    });
+
     describe('MosaicMetadataTransaction', () => {
         it('aggregate', () => {
             const mosaicMetadataTransaction = MosaicMetadataTransaction.create(

--- a/src/model/message/MessageMarker.ts
+++ b/src/model/message/MessageMarker.ts
@@ -16,7 +16,7 @@
 
 export class MessageMarker {
     /**
-     * 8-byte marker: FE2A8061577301E2 for PersistentDelegationRequestTransaction message
+     * 8-byte marker: E201735761802AFE for PersistentDelegationRequestTransaction message
      */
-    public static readonly PersistentDelegationUnlock = 'FE2A8061577301E2';
+    public static readonly PersistentDelegationUnlock = 'E201735761802AFE';
 }

--- a/src/model/message/PersistentHarvestingDelegationMessage.ts
+++ b/src/model/message/PersistentHarvestingDelegationMessage.ts
@@ -31,22 +31,23 @@ export class PersistentHarvestingDelegationMessage extends Message {
     }
 
     /**
-     *
-     * @param delegatedPrivateKey - Private key of delegated account
-     * @param recipientPublicKey - Recipient public key
+     * @param signingPrivateKey - Remote harvester signing private key linked to the main account
+     * @param vrfPrivateKey - VRF private key linked to the main account
+     * @param nodePublicKey - Node certificate public key
      * @param {NetworkType} networkType - Catapult network type
      * @return {PersistentHarvestingDelegationMessage}
      */
     public static create(
-        delegatedPrivateKey: string,
-        recipientPublicKey: string,
+        signingPrivateKey: string,
+        vrfPrivateKey: string,
+        nodePublicKey: string,
         networkType: NetworkType,
     ): PersistentHarvestingDelegationMessage {
         const ephemeralKeypair = Account.generateNewAccount(networkType);
         const encrypted =
             MessageMarker.PersistentDelegationUnlock +
             ephemeralKeypair.publicKey +
-            Crypto.encode(ephemeralKeypair.privateKey, recipientPublicKey, delegatedPrivateKey, true).toUpperCase();
+            Crypto.encode(ephemeralKeypair.privateKey, nodePublicKey, signingPrivateKey + vrfPrivateKey, true).toUpperCase();
         return new PersistentHarvestingDelegationMessage(encrypted);
     }
 
@@ -62,7 +63,7 @@ export class PersistentHarvestingDelegationMessage extends Message {
     /**
      *
      * @param encryptMessage - Encrypted message to be decrypted
-     * @param privateKey - Recipient private key
+     * @param privateKey - Node certificate private key
      * @return {string}
      */
     public static decrypt(encryptMessage: PersistentHarvestingDelegationMessage, privateKey: string): string {

--- a/src/model/transaction/PersistentDelegationRequestTransaction.ts
+++ b/src/model/transaction/PersistentDelegationRequestTransaction.ts
@@ -27,8 +27,9 @@ export class PersistentDelegationRequestTransaction extends TransferTransaction 
      * Create a PersistentDelegationRequestTransaction with special message payload
      * for presistent harvesting delegation unlocking
      * @param deadline - The deadline to include the transaction.
-     * @param delegatedPrivateKey - The private key of delegated account
-     * @param recipientPublicKey - The recipient public key
+     * @param signingPrivateKey - Remote harvester signing private key linked to the main account
+     * @param vrfPrivateKey - VRF private key linked to the main account
+     * @param nodePublicKey - Node certificate public key
      * @param networkType - The network type.
      * @param maxFee - (Optional) Max fee defined by the sender
      * @param signature - (Optional) Transaction signature
@@ -37,17 +38,18 @@ export class PersistentDelegationRequestTransaction extends TransferTransaction 
      */
     public static createPersistentDelegationRequestTransaction(
         deadline: Deadline,
-        delegatedPrivateKey: string,
-        recipientPublicKey: string,
+        signingPrivateKey: string,
+        vrfPrivateKey: string,
+        nodePublicKey: string,
         networkType: NetworkType,
         maxFee: UInt64 = new UInt64([0, 0]),
         signature?: string,
         signer?: PublicAccount,
     ): PersistentDelegationRequestTransaction {
-        const message = PersistentHarvestingDelegationMessage.create(delegatedPrivateKey, recipientPublicKey, networkType);
+        const message = PersistentHarvestingDelegationMessage.create(signingPrivateKey, vrfPrivateKey, nodePublicKey, networkType);
         return super.create(
             deadline,
-            Address.createFromPublicKey(recipientPublicKey, networkType),
+            Address.createFromPublicKey(nodePublicKey, networkType),
             [],
             message,
             networkType,

--- a/src/model/transaction/TransferTransaction.ts
+++ b/src/model/transaction/TransferTransaction.ts
@@ -171,7 +171,7 @@ export class TransferTransaction extends Transaction {
         if (this.message.type === MessageType.PersistentHarvestingDelegationMessage) {
             if (this.mosaics.length > 0) {
                 throw new Error('PersistentDelegationRequestTransaction should be created without Mosaic');
-            } else if (!/^[0-9a-fA-F]{200}$/.test(this.message.payload)) {
+            } else if (!/^[0-9a-fA-F]{264}$/.test(this.message.payload)) {
                 throw new Error('PersistentDelegationRequestTransaction message is invalid');
             }
         }

--- a/test/model/message/PersistentHarvestingDelegationMessage.spec.ts
+++ b/test/model/message/PersistentHarvestingDelegationMessage.spec.ts
@@ -26,7 +26,8 @@ describe('PersistentHarvestingDelegationMessage', () => {
     let sender: Account;
     let recipient: Account;
     let recipient_nis: Account;
-    const delegatedPrivateKey = 'F0AB1010EFEE19EE5373719881DF5123C13E643C519655F7E97347BFF77175BF';
+    const signingPrivateKey = 'F0AB1010EFEE19EE5373719881DF5123C13E643C519655F7E97347BFF77175BF';
+    const vrfPrivateKey = '800F35F1CC66C2B62CE9DD9F31003B9B3E5C7A2F381FB8952A294277A1015D83';
     before(() => {
         sender = Account.createFromPrivateKey('2602F4236B199B3DF762B2AAB46FC3B77D8DDB214F0B62538D3827576C46C108', NetworkType.MIJIN_TEST);
         recipient = Account.createFromPrivateKey(
@@ -41,11 +42,12 @@ describe('PersistentHarvestingDelegationMessage', () => {
 
     it('should create a PersistentHarvestingDelegation message', () => {
         const encryptedMessage = PersistentHarvestingDelegationMessage.create(
-            delegatedPrivateKey,
+            signingPrivateKey,
+            vrfPrivateKey,
             recipient.publicKey,
             NetworkType.MIJIN_TEST,
         );
-        expect(encryptedMessage.payload.length).to.be.equal(200);
+        expect(encryptedMessage.payload.length).to.be.equal(264);
         expect(encryptedMessage.type).to.be.equal(MessageType.PersistentHarvestingDelegationMessage);
     });
 
@@ -68,19 +70,21 @@ describe('PersistentHarvestingDelegationMessage', () => {
 
     it('should create and decrypt message', () => {
         const encryptedMessage = PersistentHarvestingDelegationMessage.create(
-            delegatedPrivateKey,
+            signingPrivateKey,
+            vrfPrivateKey,
             recipient.publicKey,
             NetworkType.MIJIN_TEST,
         );
         const plainMessage = PersistentHarvestingDelegationMessage.decrypt(encryptedMessage, recipient.privateKey);
-        expect(plainMessage).to.be.equal(delegatedPrivateKey);
+        expect(plainMessage).to.be.equal(signingPrivateKey + vrfPrivateKey);
     });
 
     it('return decrepted message reading from message payload', () => {
         const generationHash = '57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6';
         const tx = PersistentDelegationRequestTransaction.createPersistentDelegationRequestTransaction(
             Deadline.create(),
-            delegatedPrivateKey,
+            signingPrivateKey,
+            vrfPrivateKey,
             recipient.publicKey,
             NetworkType.MIJIN_TEST,
         );
@@ -89,16 +93,17 @@ describe('PersistentHarvestingDelegationMessage', () => {
             signedTransaction.payload.substring(322, signedTransaction.payload.length),
         );
         const plainMessage = PersistentHarvestingDelegationMessage.decrypt(encryptMessage, recipient.privateKey);
-        expect(plainMessage).to.be.equal(delegatedPrivateKey);
+        expect(plainMessage).to.be.equal(signingPrivateKey + vrfPrivateKey);
     });
 
     it('should encrypt and decrypt message using NIS1 schema', () => {
         const encryptedMessage = PersistentHarvestingDelegationMessage.create(
-            delegatedPrivateKey,
+            signingPrivateKey,
+            vrfPrivateKey,
             recipient_nis.publicKey,
             NetworkType.TEST_NET,
         );
         const plainMessage = PersistentHarvestingDelegationMessage.decrypt(encryptedMessage, recipient_nis.privateKey);
-        expect(plainMessage).to.be.equal(delegatedPrivateKey);
+        expect(plainMessage).to.be.equal(signingPrivateKey + vrfPrivateKey);
     });
 });

--- a/test/model/transaction/PersistentDelegationRequestTransaction.spec.ts
+++ b/test/model/transaction/PersistentDelegationRequestTransaction.spec.ts
@@ -27,6 +27,7 @@ import { TestingAccount } from '../../conf/conf.spec';
 describe('PersistentDelegationRequestTransaction', () => {
     let account: Account;
     const delegatedPrivateKey = '8A78C9E9B0E59D0F74C0D47AB29FBD523C706293A3FA9CD9FE0EEB2C10EA924A';
+    const vrfPrivateKey = '800F35F1CC66C2B62CE9DD9F31003B9B3E5C7A2F381FB8952A294277A1015D83';
     const recipientPublicKey = '9DBF67474D6E1F8B131B4EB1F5BA0595AFFAE1123607BC1048F342193D7E669F';
     const generationHash = '57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6';
     const messageMarker = MessageMarker.PersistentDelegationUnlock;
@@ -39,6 +40,7 @@ describe('PersistentDelegationRequestTransaction', () => {
         const persistentDelegationRequestTransaction = PersistentDelegationRequestTransaction.createPersistentDelegationRequestTransaction(
             Deadline.create(),
             delegatedPrivateKey,
+            vrfPrivateKey,
             recipientPublicKey,
             NetworkType.MIJIN_TEST,
         );
@@ -51,6 +53,7 @@ describe('PersistentDelegationRequestTransaction', () => {
         const persistentDelegationRequestTransaction = PersistentDelegationRequestTransaction.createPersistentDelegationRequestTransaction(
             Deadline.create(),
             delegatedPrivateKey,
+            vrfPrivateKey,
             recipientPublicKey,
             NetworkType.MIJIN_TEST,
             new UInt64([1, 0]),
@@ -64,11 +67,12 @@ describe('PersistentDelegationRequestTransaction', () => {
         const persistentDelegationRequestTransaction = PersistentDelegationRequestTransaction.createPersistentDelegationRequestTransaction(
             Deadline.create(),
             delegatedPrivateKey,
+            vrfPrivateKey,
             recipientPublicKey,
             NetworkType.MIJIN_TEST,
         );
 
-        expect(persistentDelegationRequestTransaction.message.payload.length).to.be.equal(184 + messageMarker.length);
+        expect(persistentDelegationRequestTransaction.message.payload.length).to.be.equal(248 + messageMarker.length);
         expect(persistentDelegationRequestTransaction.message.payload.includes(messageMarker)).to.be.true;
         expect(persistentDelegationRequestTransaction.mosaics.length).to.be.equal(0);
         expect(persistentDelegationRequestTransaction.recipientAddress).to.be.instanceof(Address);
@@ -90,6 +94,7 @@ describe('PersistentDelegationRequestTransaction', () => {
             PersistentDelegationRequestTransaction.createPersistentDelegationRequestTransaction(
                 Deadline.create(),
                 'abc',
+                vrfPrivateKey,
                 recipientPublicKey,
                 NetworkType.MIJIN_TEST,
                 new UInt64([1, 0]),

--- a/test/model/transaction/TransferTransaction.spec.ts
+++ b/test/model/transaction/TransferTransaction.spec.ts
@@ -44,6 +44,7 @@ describe('TransferTransaction', () => {
     let account: Account;
     const generationHash = '57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6';
     const delegatedPrivateKey = '8A78C9E9B0E59D0F74C0D47AB29FBD523C706293A3FA9CD9FE0EEB2C10EA924A';
+    const vrfPrivateKey = '800F35F1CC66C2B62CE9DD9F31003B9B3E5C7A2F381FB8952A294277A1015D83';
     const recipientPublicKey = '9DBF67474D6E1F8B131B4EB1F5BA0595AFFAE1123607BC1048F342193D7E669F';
     const messageMarker = MessageMarker.PersistentDelegationUnlock;
     let statement: Statement;
@@ -252,7 +253,7 @@ describe('TransferTransaction', () => {
             Deadline.create(),
             Address.createFromRawAddress('SATNE7Q5BITMUTRRN6IB4I7FLSDRDWZA34I2PMQ'),
             [],
-            PersistentHarvestingDelegationMessage.create(delegatedPrivateKey, recipientPublicKey, NetworkType.MIJIN_TEST),
+            PersistentHarvestingDelegationMessage.create(delegatedPrivateKey, vrfPrivateKey, recipientPublicKey, NetworkType.MIJIN_TEST),
             NetworkType.MIJIN_TEST,
         );
 
@@ -264,10 +265,10 @@ describe('TransferTransaction', () => {
             Deadline.create(),
             Address.createFromRawAddress('SATNE7Q5BITMUTRRN6IB4I7FLSDRDWZA34I2PMQ'),
             [],
-            PersistentHarvestingDelegationMessage.create(delegatedPrivateKey, recipientPublicKey, NetworkType.MIJIN_TEST),
+            PersistentHarvestingDelegationMessage.create(delegatedPrivateKey, vrfPrivateKey, recipientPublicKey, NetworkType.MIJIN_TEST),
             NetworkType.MIJIN_TEST,
         );
-        expect(transferTransaction.message.payload.length).to.be.equal(184 + messageMarker.length);
+        expect(transferTransaction.message.payload.length).to.be.equal(248 + messageMarker.length);
         expect(transferTransaction.message.payload.includes(messageMarker)).to.be.true;
         expect(transferTransaction.mosaics.length).to.be.equal(0);
         expect(transferTransaction.recipientAddress).to.be.instanceof(Address);
@@ -285,7 +286,12 @@ describe('TransferTransaction', () => {
                 Deadline.create(),
                 Address.createFromRawAddress('SATNE7Q5BITMUTRRN6IB4I7FLSDRDWZA34I2PMQ'),
                 [NetworkCurrencyLocal.createRelative(100)],
-                PersistentHarvestingDelegationMessage.create(delegatedPrivateKey, recipientPublicKey, NetworkType.MIJIN_TEST),
+                PersistentHarvestingDelegationMessage.create(
+                    delegatedPrivateKey,
+                    vrfPrivateKey,
+                    recipientPublicKey,
+                    NetworkType.MIJIN_TEST,
+                ),
                 NetworkType.MIJIN_TEST,
             );
         }).to.throw(Error, 'PersistentDelegationRequestTransaction should be created without Mosaic');
@@ -297,7 +303,7 @@ describe('TransferTransaction', () => {
                 Deadline.create(),
                 Address.createFromRawAddress('SATNE7Q5BITMUTRRN6IB4I7FLSDRDWZA34I2PMQ'),
                 [NetworkCurrencyLocal.createRelative(100)],
-                PersistentHarvestingDelegationMessage.create('abc', recipientPublicKey, NetworkType.MIJIN_TEST),
+                PersistentHarvestingDelegationMessage.create('abc', vrfPrivateKey, recipientPublicKey, NetworkType.MIJIN_TEST),
                 NetworkType.MIJIN_TEST,
             );
         }).to.throw();
@@ -309,7 +315,12 @@ describe('TransferTransaction', () => {
                 Deadline.create(),
                 Address.createFromRawAddress('SATNE7Q5BITMUTRRN6IB4I7FLSDRDWZA34I2PMQ'),
                 [NetworkCurrencyLocal.createRelative(100)],
-                PersistentHarvestingDelegationMessage.create(delegatedPrivateKey, recipientPublicKey, NetworkType.MIJIN_TEST),
+                PersistentHarvestingDelegationMessage.create(
+                    delegatedPrivateKey,
+                    vrfPrivateKey,
+                    recipientPublicKey,
+                    NetworkType.MIJIN_TEST,
+                ),
                 NetworkType.MIJIN_TEST,
             );
         }).to.throw();


### PR DESCRIPTION
- Updated delegated harvesting message marker to `E201735761802AFE`
- Added vrf private key to the message payload, so the encrypted message payload becomes `signingPrivateKey + vrfPrivateKey`


Fixed  - #147