### PR TITLE
Symbol-bootstrap integration for e2e

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ dist/
 ts-docs
 docs/
 .vscode/launch.json
+/target/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ cache:
   directories:
     - "node_modules"
     - .eslintcache
+jobs:
+  include:
+    - stage: e2e
+      script: npm run test:e2e
+      if: branch = e2e
 before_script:
   - npm run build
   - if [ "$TRAVIS_NODE_VERSION" = "10" ] || [ "$TRAVIS_NODE_VERSION" = "12" ]; then npm run lint; fi

--- a/e2e/e2e-preset.yml
+++ b/e2e/e2e-preset.yml
@@ -1,0 +1,3 @@
+nemesis:
+    mosaics:
+        - accounts: 10

--- a/e2e/infrastructure/AccountHttp.spec.ts
+++ b/e2e/infrastructure/AccountHttp.spec.ts
@@ -57,7 +57,7 @@ describe('AccountHttp', () => {
     let networkType: NetworkType;
 
     before(() => {
-        return helper.start().then(() => {
+        return helper.start({ openListener: true }).then(() => {
             account = helper.account;
             account2 = helper.account2;
             multisigAccount = helper.multisigAccount;
@@ -73,12 +73,9 @@ describe('AccountHttp', () => {
             namespaceRepository = helper.repositoryFactory.createNamespaceRepository();
         });
     });
-    before(() => {
-        return helper.listener.open();
-    });
 
     after(() => {
-        helper.listener.close();
+        return helper.close();
     });
 
     /**

--- a/e2e/infrastructure/BlockHttp.spec.ts
+++ b/e2e/infrastructure/BlockHttp.spec.ts
@@ -44,7 +44,7 @@ describe('BlockHttp', () => {
     let transactionHash;
 
     before(() => {
-        return helper.start().then(() => {
+        return helper.start({ openListener: true }).then(() => {
             account = helper.account;
             account2 = helper.account2;
             generationHash = helper.generationHash;
@@ -54,12 +54,8 @@ describe('BlockHttp', () => {
         });
     });
 
-    before(() => {
-        return helper.listener.open();
-    });
-
     after(() => {
-        helper.listener.close();
+        return helper.close();
     });
 
     /**
@@ -69,7 +65,7 @@ describe('BlockHttp', () => {
      */
 
     describe('Setup Test Data', () => {
-        it('Announce TransferTransaction', () => {
+        it('Announce TransferTransaction FER', () => {
             const transferTransaction = TransferTransaction.create(
                 Deadline.create(),
                 account2.address,

--- a/e2e/infrastructure/ChainHttp.spec.ts
+++ b/e2e/infrastructure/ChainHttp.spec.ts
@@ -23,9 +23,13 @@ describe('ChainHttp', () => {
     let chainRepository: ChainRepository;
 
     before(() => {
-        return helper.start().then(() => {
+        return helper.start({ openListener: false }).then(() => {
             chainRepository = helper.repositoryFactory.createChainRepository();
         });
+    });
+
+    after(() => {
+        return helper.close();
     });
 
     describe('getBlockchainHeight', () => {

--- a/e2e/infrastructure/Listener.spec.ts
+++ b/e2e/infrastructure/Listener.spec.ts
@@ -48,7 +48,7 @@ describe('Listener', () => {
     let transactionRepository: TransactionRepository;
 
     before(() => {
-        return helper.start().then(() => {
+        return helper.start({ openListener: true }).then(() => {
             account = helper.account;
             account2 = helper.account2;
             multisigAccount = helper.multisigAccount;
@@ -60,12 +60,9 @@ describe('Listener', () => {
             transactionRepository = helper.repositoryFactory.createTransactionRepository();
         });
     });
-    before(() => {
-        return helper.listener.open();
-    });
 
     after(() => {
-        helper.listener.close();
+        return helper.close();
     });
     afterEach((done) => {
         // cold down

--- a/e2e/infrastructure/MetadataHttp.spec.ts
+++ b/e2e/infrastructure/MetadataHttp.spec.ts
@@ -48,7 +48,7 @@ describe('MetadataHttp', () => {
     let metadataRepository: MetadataRepository;
 
     before(() => {
-        return helper.start().then(() => {
+        return helper.start({ openListener: true }).then(() => {
             account = helper.account;
             accountAddress = helper.account.address;
             generationHash = helper.generationHash;
@@ -57,12 +57,8 @@ describe('MetadataHttp', () => {
         });
     });
 
-    before(() => {
-        return helper.listener.open();
-    });
-
     after(() => {
-        helper.listener.close();
+        return helper.close();
     });
 
     /**

--- a/e2e/infrastructure/MosaicHttp.spec.ts
+++ b/e2e/infrastructure/MosaicHttp.spec.ts
@@ -45,7 +45,7 @@ describe('MosaicHttp', () => {
     let networkType: NetworkType;
 
     before(() => {
-        return helper.start().then(() => {
+        return helper.start({ openListener: true }).then(() => {
             account = helper.account;
             generationHash = helper.generationHash;
             networkType = helper.networkType;
@@ -53,12 +53,9 @@ describe('MosaicHttp', () => {
             mosaicRepository = helper.repositoryFactory.createMosaicRepository();
         });
     });
-    before(() => {
-        return helper.listener.open();
-    });
 
     after(() => {
-        helper.listener.close();
+        return helper.close();
     });
 
     /**

--- a/e2e/infrastructure/MultisigAccounts.spec.ts
+++ b/e2e/infrastructure/MultisigAccounts.spec.ts
@@ -30,7 +30,7 @@ describe('MultisigAccounts', () => {
     let networkType: NetworkType;
 
     before(() => {
-        return helper.start().then(() => {
+        return helper.start({ openListener: true }).then(() => {
             multisigAccount = helper.multisigAccount;
             cosignAccount1 = helper.cosignAccount1;
             cosignAccount2 = helper.cosignAccount2;
@@ -39,12 +39,9 @@ describe('MultisigAccounts', () => {
             networkType = helper.networkType;
         });
     });
-    before(() => {
-        return helper.listener.open();
-    });
 
     after(() => {
-        helper.listener.close();
+        return helper.close();
     });
 
     describe('Setup test multisig account', () => {

--- a/e2e/infrastructure/NamespaceHttp.spec.ts
+++ b/e2e/infrastructure/NamespaceHttp.spec.ts
@@ -38,7 +38,7 @@ describe('NamespaceHttp', () => {
     const helper = new IntegrationTestHelper();
 
     before(() => {
-        return helper.start().then(() => {
+        return helper.start({ openListener: true }).then(() => {
             account = helper.account;
             generationHash = helper.generationHash;
             namespaceRepository = helper.repositoryFactory.createNamespaceRepository();
@@ -46,12 +46,8 @@ describe('NamespaceHttp', () => {
         });
     });
 
-    before(() => {
-        return helper.listener.open();
-    });
-
     after(() => {
-        helper.listener.close();
+        return helper.close();
     });
 
     describe('NamespaceRegistrationTransaction', () => {

--- a/e2e/infrastructure/NetworkHttp.spec.ts
+++ b/e2e/infrastructure/NetworkHttp.spec.ts
@@ -24,10 +24,14 @@ describe('NetworkHttp', () => {
     let networkType: NetworkType;
 
     before(() => {
-        return helper.start().then(() => {
+        return helper.start({ openListener: false }).then(() => {
             networkRepository = helper.repositoryFactory.createNetworkRepository();
             networkType = helper.networkType;
         });
+    });
+
+    after(() => {
+        return helper.close();
     });
 
     describe('getNetworkType', () => {

--- a/e2e/infrastructure/NodeHttp.spec.ts
+++ b/e2e/infrastructure/NodeHttp.spec.ts
@@ -23,13 +23,17 @@ describe('NodeHttp', () => {
     const helper = new IntegrationTestHelper();
 
     before(() => {
-        return helper.start().then(() => {
+        return helper.start({ openListener: false }).then(() => {
             nodeRepository = helper.repositoryFactory.createNodeRepository();
         });
     });
 
+    after(() => {
+        return helper.close();
+    });
+
     describe('getNodeInfo', () => {
-        it('should return node info', async () => {
+        it('should return node info FER', async () => {
             const nodeInfo = await nodeRepository.getNodeInfo().toPromise();
             expect(nodeInfo.friendlyName).not.to.be.undefined;
             expect(nodeInfo.host).not.to.be.undefined;

--- a/e2e/infrastructure/PersistentHarvesting.spec.ts
+++ b/e2e/infrastructure/PersistentHarvesting.spec.ts
@@ -36,7 +36,7 @@ describe('PersistentHarvesting', () => {
     );
 
     before(() => {
-        return helper.start().then(() => {
+        return helper.start({ openListener: true }).then(() => {
             remoteAccount = Account.generateNewAccount(helper.networkType);
             console.log(remoteAccount.privateKey, remoteAccount.publicAccount);
             account = helper.harvestingAccount;
@@ -44,12 +44,9 @@ describe('PersistentHarvesting', () => {
             networkType = helper.networkType;
         });
     });
-    before(() => {
-        return helper.listener.open();
-    });
 
     after(() => {
-        helper.listener.close();
+        return helper.close();
     });
 
     /**

--- a/e2e/infrastructure/ReceiptHttp.spec.ts
+++ b/e2e/infrastructure/ReceiptHttp.spec.ts
@@ -27,13 +27,17 @@ describe('ReceiptHttp', () => {
     let receiptRepository: ReceiptRepository;
 
     before(() => {
-        return helper.start().then(() => {
+        return helper.start({ openListener: false }).then(() => {
             receiptRepository = helper.repositoryFactory.createReceiptRepository();
         });
     });
 
+    after(() => {
+        return helper.close();
+    });
+
     describe('searchReceipt with streamer and recipient type type', () => {
-        async function searchByRecipientType(receiptTypes: ReceiptType[], empty: boolean) {
+        async function searchByRecipientType(receiptTypes: ReceiptType[], empty: boolean): Promise<void> {
             const streamer = ReceiptPaginationStreamer.transactionStatements(receiptRepository);
 
             const infos = await streamer

--- a/e2e/infrastructure/RestrictionHttp.spec.ts
+++ b/e2e/infrastructure/RestrictionHttp.spec.ts
@@ -49,7 +49,7 @@ describe('RestrictionHttp', () => {
     let restrictionAccountRepository: RestrictionAccountRepository;
 
     before(() => {
-        return helper.start().then(() => {
+        return helper.start({ openListener: true }).then(() => {
             account = helper.account;
             account3 = helper.account3;
             accountAddress = helper.account.address;
@@ -59,12 +59,9 @@ describe('RestrictionHttp', () => {
             restrictionAccountRepository = helper.repositoryFactory.createRestrictionAccountRepository();
         });
     });
-    before(() => {
-        return helper.listener.open();
-    });
 
     after(() => {
-        helper.listener.close();
+        return helper.close();
     });
 
     /**

--- a/e2e/infrastructure/TransactionHttp.spec.ts
+++ b/e2e/infrastructure/TransactionHttp.spec.ts
@@ -106,7 +106,7 @@ describe('TransactionHttp', () => {
     const remoteAccount = Account.generateNewAccount(helper.networkType);
 
     before(() => {
-        return helper.start().then(() => {
+        return helper.start({ openListener: true }).then(() => {
             account = helper.account;
             account2 = helper.account2;
             account3 = helper.account3;
@@ -121,12 +121,9 @@ describe('TransactionHttp', () => {
             transactionStatusRepository = helper.repositoryFactory.createTransactionStatusRepository();
         });
     });
-    before(() => {
-        return helper.listener.open();
-    });
 
     after(() => {
-        helper.listener.close();
+        return helper.close();
     });
 
     describe('Get network currency mosaic id', () => {

--- a/e2e/infrastructure/UnresolvedMapping.spec.ts
+++ b/e2e/infrastructure/UnresolvedMapping.spec.ts
@@ -50,7 +50,7 @@ describe('Unresolved Mapping', () => {
     let namespaceIdMosaic: NamespaceId;
 
     before(() => {
-        return helper.start().then(() => {
+        return helper.start({ openListener: true }).then(() => {
             account = helper.account;
             account2 = helper.account2;
             generationHash = helper.generationHash;
@@ -58,12 +58,8 @@ describe('Unresolved Mapping', () => {
         });
     });
 
-    before(() => {
-        return helper.listener.open();
-    });
-
     after(() => {
-        helper.listener.close();
+        return helper.close();
     });
 
     /**

--- a/e2e/service/AccountService.spec.ts
+++ b/e2e/service/AccountService.spec.ts
@@ -34,19 +34,16 @@ describe('AccountService', () => {
     const name = 'root-test-namespace-' + Math.floor(Math.random() * 10000);
 
     before(() => {
-        return helper.start().then(() => {
+        return helper.start({ openListener: true }).then(() => {
             account = helper.account;
             generationHash = helper.generationHash;
             networkType = helper.networkType;
             accountService = new AccountService(helper.repositoryFactory);
         });
     });
-    before(() => {
-        return helper.listener.open();
-    });
 
     after(() => {
-        helper.listener.close();
+        return helper.close();
     });
 
     /**

--- a/e2e/service/BlockService.spec.ts
+++ b/e2e/service/BlockService.spec.ts
@@ -41,7 +41,7 @@ describe('BlockService', () => {
     let receiptRepository: ReceiptRepository;
 
     before(() => {
-        return helper.start().then(() => {
+        return helper.start({ openListener: true }).then(() => {
             account = helper.account;
             account2 = helper.account2;
             generationHash = helper.generationHash;
@@ -51,12 +51,9 @@ describe('BlockService', () => {
             blockService = new BlockService(helper.repositoryFactory);
         });
     });
-    before(() => {
-        return helper.listener.open();
-    });
 
     after(() => {
-        helper.listener.close();
+        return helper.close();
     });
 
     /**

--- a/e2e/service/MetadataTransactionService.spec.ts
+++ b/e2e/service/MetadataTransactionService.spec.ts
@@ -33,7 +33,7 @@ describe('MetadataTransactionService', () => {
     let generationHash: string;
 
     before(() => {
-        return helper.start().then(() => {
+        return helper.start({ openListener: true }).then(() => {
             targetAccount = helper.account;
             generationHash = helper.generationHash;
             networkType = helper.networkType;
@@ -41,12 +41,8 @@ describe('MetadataTransactionService', () => {
         });
     });
 
-    before(() => {
-        return helper.listener.open();
-    });
-
     after(() => {
-        helper.listener.close();
+        return helper.close();
     });
 
     /**

--- a/e2e/service/MosaicRestrictionTransactionService.spec.ts
+++ b/e2e/service/MosaicRestrictionTransactionService.spec.ts
@@ -37,7 +37,7 @@ describe('MosaicRestrictionTransactionService', () => {
     let namespaceIdMosaic: NamespaceId;
 
     before(() => {
-        return helper.start().then(() => {
+        return helper.start({ openListener: true }).then(() => {
             account = helper.account;
             generationHash = helper.generationHash;
             networkType = helper.networkType;
@@ -46,12 +46,8 @@ describe('MosaicRestrictionTransactionService', () => {
         });
     });
 
-    before(() => {
-        return helper.listener.open();
-    });
-
     after(() => {
-        helper.listener.close();
+        return helper.close();
     });
 
     /**

--- a/e2e/service/MosaicService.spec.ts
+++ b/e2e/service/MosaicService.spec.ts
@@ -27,12 +27,17 @@ describe('MosaicService', () => {
     const helper = new IntegrationTestHelper();
 
     before(() => {
-        return helper.start().then(() => {
+        return helper.start({ openListener: false }).then(() => {
             accountAddress = helper.account.address;
             accountRepository = helper.repositoryFactory.createAccountRepository();
             mosaicRepository = helper.repositoryFactory.createMosaicRepository();
         });
     });
+
+    after(() => {
+        return helper.close();
+    });
+
     it('should return the mosaic list skipping the expired mosaics', () => {
         const mosaicService = new MosaicService(accountRepository, mosaicRepository);
         return mosaicService

--- a/e2e/service/TransactionService.spec.ts
+++ b/e2e/service/TransactionService.spec.ts
@@ -61,7 +61,7 @@ describe('TransactionService', () => {
     let transactionRepository: TransactionRepository;
 
     before(() => {
-        return helper.start().then(() => {
+        return helper.start({ openListener: true }).then(() => {
             account = helper.account;
             account2 = helper.account2;
             account3 = helper.account3;
@@ -77,12 +77,9 @@ describe('TransactionService', () => {
             );
         });
     });
-    before(() => {
-        return helper.listener.open();
-    });
 
     after(() => {
-        helper.listener.close();
+        return helper.close();
     });
 
     function buildAggregateTransaction(): AggregateTransaction {

--- a/e2e/service/TransactionService_AggregateBonded.spec.ts
+++ b/e2e/service/TransactionService_AggregateBonded.spec.ts
@@ -51,7 +51,7 @@ describe('TransactionService - AggregateBonded', () => {
     let NetworkCurrencyLocalId: MosaicId;
 
     before(() => {
-        return helper.start().then(() => {
+        return helper.start({ openListener: true }).then(() => {
             account = helper.account;
             account2 = helper.account2;
             multisigAccount = helper.multisigAccount;
@@ -67,12 +67,9 @@ describe('TransactionService - AggregateBonded', () => {
             );
         });
     });
-    before(() => {
-        return helper.listener.open();
-    });
 
     after(() => {
-        helper.listener.close();
+        return helper.close();
     });
 
     const createSignedAggregatedBondTransaction = (aggregatedTo: Account, signer: Account, recipient: Address): SignedTransaction => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -289,6 +289,17 @@
                 "to-fast-properties": "^2.0.0"
             }
         },
+        "@dabh/diagnostics": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
+            "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
+            "dev": true,
+            "requires": {
+                "colorspace": "1.1.x",
+                "enabled": "2.0.x",
+                "kuler": "^2.0.0"
+            }
+        },
         "@istanbuljs/load-nyc-config": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
@@ -330,6 +341,295 @@
             "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
             "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
             "dev": true
+        },
+        "@nodelib/fs.scandir": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+            "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.stat": "2.0.3",
+                "run-parallel": "^1.1.9"
+            }
+        },
+        "@nodelib/fs.stat": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+            "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+            "dev": true
+        },
+        "@nodelib/fs.walk": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+            "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.scandir": "2.1.3",
+                "fastq": "^1.6.0"
+            }
+        },
+        "@oclif/command": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
+            "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
+            "dev": true,
+            "requires": {
+                "@oclif/config": "^1.15.1",
+                "@oclif/errors": "^1.3.3",
+                "@oclif/parser": "^3.8.3",
+                "@oclif/plugin-help": "^3",
+                "debug": "^4.1.1",
+                "semver": "^7.3.2"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "7.3.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+                    "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+                    "dev": true
+                }
+            }
+        },
+        "@oclif/config": {
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.17.0.tgz",
+            "integrity": "sha512-Lmfuf6ubjQ4ifC/9bz1fSCHc6F6E653oyaRXxg+lgT4+bYf9bk+nqrUpAbrXyABkCqgIBiFr3J4zR/kiFdE1PA==",
+            "dev": true,
+            "requires": {
+                "@oclif/errors": "^1.3.3",
+                "@oclif/parser": "^3.8.0",
+                "debug": "^4.1.1",
+                "globby": "^11.0.1",
+                "is-wsl": "^2.1.1",
+                "tslib": "^2.0.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+                    "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
+                    "dev": true
+                }
+            }
+        },
+        "@oclif/errors": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.3.tgz",
+            "integrity": "sha512-EJR6AIOEkt/NnARNIVAskPDVtdhtO5TTNXmhDrGqMoWVsr0R6DkkLrMyq95BmHvlVWM1nduoq4fQPuCyuF2jaA==",
+            "dev": true,
+            "requires": {
+                "clean-stack": "^3.0.0",
+                "fs-extra": "^9.0.1",
+                "indent-string": "^4.0.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "clean-stack": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.0.tgz",
+                    "integrity": "sha512-RHxtgFvXsRQ+1AM7dlozLDY7ssmvUUh0XEnfnyhYgJTO6beNZHBogiaCwGM9Q3rFrUkYxOtsZRC0zAturg5bjg==",
+                    "dev": true,
+                    "requires": {
+                        "escape-string-regexp": "4.0.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "escape-string-regexp": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+                    "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                }
+            }
+        },
+        "@oclif/linewrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
+            "integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==",
+            "dev": true
+        },
+        "@oclif/parser": {
+            "version": "3.8.5",
+            "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.5.tgz",
+            "integrity": "sha512-yojzeEfmSxjjkAvMRj0KzspXlMjCfBzNRPkWw8ZwOSoNWoJn+OCS/m/S+yfV6BvAM4u2lTzX9Y5rCbrFIgkJLg==",
+            "dev": true,
+            "requires": {
+                "@oclif/errors": "^1.2.2",
+                "@oclif/linewrap": "^1.0.0",
+                "chalk": "^2.4.2",
+                "tslib": "^1.9.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.13.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+                    "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+                    "dev": true
+                }
+            }
+        },
+        "@oclif/plugin-help": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.0.tgz",
+            "integrity": "sha512-7jxtpwVWAVbp1r46ZnTK/uF+FeZc6y4p1XcGaIUuPAp7wx6NJhIRN/iMT9UfNFX/Cz7mq+OyJz+E+i0zrik86g==",
+            "dev": true,
+            "requires": {
+                "@oclif/command": "^1.5.20",
+                "@oclif/config": "^1.15.1",
+                "chalk": "^2.4.1",
+                "indent-string": "^4.0.0",
+                "lodash.template": "^4.4.0",
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "widest-line": "^3.1.0",
+                "wrap-ansi": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-4.0.0.tgz",
+                    "integrity": "sha512-uMTsj9rDb0/7kk1PbcbCcwvHUxp60fGDB/NNXpVa0Q+ic/e7y5+BwTxKfQ33VYgDppSwi/FBzpetYzo8s6tfbg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.0",
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                            "dev": true
+                        },
+                        "is-fullwidth-code-point": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                            "dev": true
+                        },
+                        "string-width": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                            "dev": true,
+                            "requires": {
+                                "is-fullwidth-code-point": "^2.0.0",
+                                "strip-ansi": "^4.0.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            }
+                        }
+                    }
+                }
+            }
         },
         "@types/caseless": {
             "version": "0.12.1",
@@ -777,6 +1077,12 @@
                 }
             }
         },
+        "array-union": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+            "dev": true
+        },
         "array-unique": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
@@ -831,6 +1137,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
             "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+            "dev": true
+        },
+        "async": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+            "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
             "dev": true
         },
         "async-done": {
@@ -973,6 +1285,12 @@
                 }
             }
         },
+        "base64-js": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+            "dev": true
+        },
         "bcrypt-pbkdf": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
@@ -995,6 +1313,36 @@
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
             "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
             "dev": true
+        },
+        "bl": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+            "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+            "dev": true,
+            "requires": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+                    "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
         },
         "bluebird": {
             "version": "3.7.2",
@@ -1045,6 +1393,16 @@
             "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
+        },
+        "buffer": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+            "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+            "dev": true,
+            "requires": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4"
+            }
         },
         "buffer-equal": {
             "version": "1.0.0",
@@ -1179,6 +1537,12 @@
                 }
             }
         },
+        "chownr": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+            "dev": true
+        },
         "class-utils": {
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -1290,6 +1654,16 @@
                 "object-visit": "^1.0.0"
             }
         },
+        "color": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+            "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+            "dev": true,
+            "requires": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+            }
+        },
         "color-convert": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
@@ -1305,11 +1679,37 @@
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
             "dev": true
         },
+        "color-string": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+            "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+            "dev": true,
+            "requires": {
+                "color-name": "^1.0.0",
+                "simple-swizzle": "^0.2.2"
+            }
+        },
         "color-support": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
             "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
             "dev": true
+        },
+        "colors": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+            "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+            "dev": true
+        },
+        "colorspace": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+            "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+            "dev": true,
+            "requires": {
+                "color": "3.0.x",
+                "text-hex": "1.0.x"
+            }
         },
         "combined-stream": {
             "version": "1.0.6",
@@ -1586,6 +1986,58 @@
             "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
             "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
         },
+        "dir-glob": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "dev": true,
+            "requires": {
+                "path-type": "^4.0.0"
+            },
+            "dependencies": {
+                "path-type": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+                    "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+                    "dev": true
+                }
+            }
+        },
+        "docker-modem": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-2.1.4.tgz",
+            "integrity": "sha512-vDTzZjjO1sXMY7m0xKjGdFMMZL7vIUerkC3G4l6rnrpOET2M6AOufM8ajmQoOB+6RfSn6I/dlikCUq/Y91Q1sQ==",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.1",
+                "readable-stream": "^3.5.0",
+                "split-ca": "^1.0.1",
+                "ssh2": "^0.8.7"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "dockerode": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.2.1.tgz",
+            "integrity": "sha512-XsSVB5Wu5HWMg1aelV5hFSqFJaKS5x1aiV/+sT7YOzOq1IRl49I/UwV8Pe4x6t0iF9kiGkWu5jwfvbkcFVupBw==",
+            "dev": true,
+            "requires": {
+                "docker-modem": "^2.1.0",
+                "tar-fs": "~2.0.1"
+            }
+        },
         "doctrine": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -1630,6 +2082,12 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
+        },
+        "enabled": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+            "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
             "dev": true
         },
         "end-of-stream": {
@@ -2194,6 +2652,74 @@
             "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
             "dev": true
         },
+        "fast-glob": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+            "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.0",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.2",
+                "picomatch": "^2.2.1"
+            },
+            "dependencies": {
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "glob-parent": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+                    "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^4.0.1"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.0.5"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
+            }
+        },
         "fast-json-stable-stringify": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -2203,6 +2729,33 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
+        "fast-safe-stringify": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+            "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
+            "dev": true
+        },
+        "fastq": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+            "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+            "dev": true,
+            "requires": {
+                "reusify": "^1.0.4"
+            }
+        },
+        "fecha": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
+            "integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg==",
+            "dev": true
+        },
+        "figlet": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.5.0.tgz",
+            "integrity": "sha512-ZQJM4aifMpz6H19AW1VqvZ7l4pOE9p7i/3LyxgO2kp+PO/VcDYNqIHEMtkccqIhTXMKci4kjueJr/iCQEaT/Ww==",
             "dev": true
         },
         "figures": {
@@ -2367,6 +2920,12 @@
                 "readable-stream": "^2.3.6"
             }
         },
+        "fn.name": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+            "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+            "dev": true
+        },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2420,6 +2979,12 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.0.tgz",
             "integrity": "sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ==",
+            "dev": true
+        },
+        "fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
             "dev": true
         },
         "fs-extra": {
@@ -3165,6 +3730,28 @@
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
             "dev": true
         },
+        "globby": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+            "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+            "dev": true,
+            "requires": {
+                "array-union": "^2.1.0",
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.1.1",
+                "ignore": "^5.1.4",
+                "merge2": "^1.3.0",
+                "slash": "^3.0.0"
+            },
+            "dependencies": {
+                "ignore": {
+                    "version": "5.1.8",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+                    "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+                    "dev": true
+                }
+            }
+        },
         "glogg": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
@@ -3430,6 +4017,12 @@
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
             }
+        },
+        "ieee754": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+            "dev": true
         },
         "ignore": {
             "version": "4.0.6",
@@ -3713,6 +4306,12 @@
                 }
             }
         },
+        "is-docker": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+            "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
+            "dev": true
+        },
         "is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -3882,6 +4481,15 @@
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
             "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
             "dev": true
+        },
+        "is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dev": true,
+            "requires": {
+                "is-docker": "^2.0.0"
+            }
         },
         "isarray": {
             "version": "1.0.0",
@@ -4128,6 +4736,12 @@
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true
         },
+        "kuler": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+            "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+            "dev": true
+        },
         "last-run": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
@@ -4210,6 +4824,12 @@
                 "strip-bom": "^2.0.0"
             }
         },
+        "loadash": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/loadash/-/loadash-1.0.0.tgz",
+            "integrity": "sha512-xlX5HBsXB3KG0FJbJJG/3kYWCfsCyCSus3T+uHVu6QL6YxAdggmm3QeyLgn54N2yi5/UE6xxL5ZWJAAiHzHYEg==",
+            "dev": true
+        },
         "locate-path": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -4224,11 +4844,36 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
             "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
         },
+        "lodash._reinterpolate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+            "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+            "dev": true
+        },
         "lodash.flattendeep": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
             "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
             "dev": true
+        },
+        "lodash.template": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+            "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+            "dev": true,
+            "requires": {
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.templatesettings": "^4.0.0"
+            }
+        },
+        "lodash.templatesettings": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+            "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+            "dev": true,
+            "requires": {
+                "lodash._reinterpolate": "^3.0.0"
+            }
         },
         "log-driver": {
             "version": "1.2.7",
@@ -4243,6 +4888,27 @@
             "dev": true,
             "requires": {
                 "chalk": "^2.4.2"
+            }
+        },
+        "logform": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
+            "integrity": "sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==",
+            "dev": true,
+            "requires": {
+                "colors": "^1.2.1",
+                "fast-safe-stringify": "^2.0.4",
+                "fecha": "^4.2.0",
+                "ms": "^2.1.1",
+                "triple-beam": "^1.3.0"
+            },
+            "dependencies": {
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
             }
         },
         "long": {
@@ -4353,6 +5019,18 @@
                     }
                 }
             }
+        },
+        "memorystream": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+            "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+            "dev": true
+        },
+        "merge2": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true
         },
         "merkle-lib": {
             "version": "2.0.10",
@@ -4474,6 +5152,12 @@
                     "dev": true
                 }
             }
+        },
+        "mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+            "dev": true
         },
         "mocha": {
             "version": "8.0.1",
@@ -4910,6 +5594,12 @@
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
             "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
         },
+        "node-forge": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
+            "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ==",
+            "dev": true
+        },
         "node-preload": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
@@ -5310,6 +6000,15 @@
             "dev": true,
             "requires": {
                 "wrappy": "1"
+            }
+        },
+        "one-time": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+            "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+            "dev": true,
+            "requires": {
+                "fn.name": "1.x.x"
             }
         },
         "onetime": {
@@ -6029,6 +6728,12 @@
             "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
             "dev": true
         },
+        "reusify": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "dev": true
+        },
         "rimraf": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -6071,6 +6776,12 @@
             "requires": {
                 "is-promise": "^2.1.0"
             }
+        },
+        "run-parallel": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+            "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+            "dev": true
         },
         "rxjs": {
             "version": "6.5.3",
@@ -6202,6 +6913,29 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "dev": true
+        },
+        "simple-swizzle": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+            "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+            "dev": true,
+            "requires": {
+                "is-arrayish": "^0.3.1"
+            },
+            "dependencies": {
+                "is-arrayish": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+                    "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+                    "dev": true
+                }
+            }
+        },
+        "slash": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "dev": true
         },
         "slice-ansi": {
@@ -6437,6 +7171,12 @@
             "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
             "dev": true
         },
+        "split-ca": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+            "integrity": "sha1-bIOv82kvphJW4M0ZfgXp3hV2kaY=",
+            "dev": true
+        },
         "split-string": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -6451,6 +7191,43 @@
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
+        },
+        "ssh2": {
+            "version": "0.8.9",
+            "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.9.tgz",
+            "integrity": "sha512-GmoNPxWDMkVpMFa9LVVzQZHF6EW3WKmBwL+4/GeILf2hFmix5Isxm7Amamo8o7bHiU0tC+wXsGcUXOxp8ChPaw==",
+            "dev": true,
+            "requires": {
+                "ssh2-streams": "~0.4.10"
+            }
+        },
+        "ssh2-streams": {
+            "version": "0.4.10",
+            "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.10.tgz",
+            "integrity": "sha512-8pnlMjvnIZJvmTzUIIA5nT4jr2ZWNNVHwyXfMGdRJbug9TpI3kd99ffglgfSWqujVv/0gxwMsDn9j9RVst8yhQ==",
+            "dev": true,
+            "requires": {
+                "asn1": "~0.2.0",
+                "bcrypt-pbkdf": "^1.0.2",
+                "streamsearch": "~0.1.2"
+            },
+            "dependencies": {
+                "bcrypt-pbkdf": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+                    "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+                    "dev": true,
+                    "requires": {
+                        "tweetnacl": "^0.14.3"
+                    }
+                },
+                "tweetnacl": {
+                    "version": "0.14.5",
+                    "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                    "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+                    "dev": true
+                }
+            }
         },
         "sshpk": {
             "version": "1.14.1",
@@ -6517,6 +7294,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
             "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+            "dev": true
+        },
+        "streamsearch": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+            "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
             "dev": true
         },
         "string-width": {
@@ -6610,10 +7393,86 @@
                 "es6-symbol": "^3.1.1"
             }
         },
+        "symbol-bootstrap": {
+            "version": "0.0.0-alpha-202008261328",
+            "resolved": "https://registry.npmjs.org/symbol-bootstrap/-/symbol-bootstrap-0.0.0-alpha-202008261328.tgz",
+            "integrity": "sha512-Gi7vRebB/ChMjIQrsS/1XPLI+Y+KlRPbBECDRa6Ovoqun8pnvDbLNrX9jA00gNX3nN+gOmXjZK3KleRofj4PMg==",
+            "dev": true,
+            "requires": {
+                "@oclif/command": "^1.7.0",
+                "@oclif/config": "^1.16.0",
+                "@oclif/plugin-help": "^3.1.0",
+                "dockerode": "^3.2.1",
+                "figlet": "^1.2.4",
+                "handlebars": "^4.7.6",
+                "js-yaml": "^3.14.0",
+                "loadash": "^1.0.0",
+                "memorystream": "^0.3.1",
+                "node-forge": "^0.9.1",
+                "symbol-sdk": "^0.20.8-alpha-202008211131",
+                "tslib": "^1.13.0",
+                "utf8": "^2.1.2",
+                "winston": "^3.3.3"
+            },
+            "dependencies": {
+                "js-yaml": {
+                    "version": "3.14.0",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+                    "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+                    "dev": true,
+                    "requires": {
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
+                    }
+                },
+                "tslib": {
+                    "version": "1.13.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+                    "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+                    "dev": true
+                },
+                "utf8": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
+                    "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY=",
+                    "dev": true
+                }
+            }
+        },
         "symbol-openapi-typescript-fetch-client": {
             "version": "0.9.6",
             "resolved": "https://registry.npmjs.org/symbol-openapi-typescript-fetch-client/-/symbol-openapi-typescript-fetch-client-0.9.6.tgz",
             "integrity": "sha512-ZZtR031IBkYfiG0bR26vGckKmUrJzY9sggXMusrqloxweNovtzf7Aqpx7nNEpCJdMNzwv+E0V8mYBwxgFuiMfg=="
+        },
+        "symbol-sdk": {
+            "version": "0.20.8-alpha-202008211131",
+            "resolved": "https://registry.npmjs.org/symbol-sdk/-/symbol-sdk-0.20.8-alpha-202008211131.tgz",
+            "integrity": "sha512-BbRvPICmKkQjLQosZxaPpGhTGi188vxFBM5v+BBJDzKnM8ZYHLc0VACQrkmvIlnWCIeCx8LlA2LiRVUcKdICbg==",
+            "dev": true,
+            "requires": {
+                "bluebird": "^3.7.2",
+                "catbuffer-typescript": "0.0.21",
+                "crypto-js": "^4.0.0",
+                "diff": "^4.0.2",
+                "futoin-hkdf": "^1.3.1",
+                "js-joda": "^1.6.2",
+                "js-sha256": "^0.9.0",
+                "js-sha3": "^0.8.0",
+                "js-sha512": "^0.8.0",
+                "long": "^4.0.0",
+                "merkletreejs": "^0.1.7",
+                "minimist": "^1.2.5",
+                "node-fetch": "^2.6.0",
+                "request": "^2.88.0",
+                "request-promise-native": "^1.0.5",
+                "ripemd160": "^2.0.2",
+                "rxjs": "^6.5.3",
+                "rxjs-compat": "^6.5.3",
+                "symbol-openapi-typescript-fetch-client": "0.9.6",
+                "tweetnacl": "^1.0.3",
+                "utf8": "^3.0.0",
+                "ws": "^7.2.3"
+            }
         },
         "table": {
             "version": "5.4.6",
@@ -6667,6 +7526,56 @@
                 }
             }
         },
+        "tar-fs": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
+            "integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
+            "dev": true,
+            "requires": {
+                "chownr": "^1.1.1",
+                "mkdirp-classic": "^0.5.2",
+                "pump": "^3.0.0",
+                "tar-stream": "^2.0.0"
+            },
+            "dependencies": {
+                "pump": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+                    "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
+                    }
+                }
+            }
+        },
+        "tar-stream": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
+            "integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
+            "dev": true,
+            "requires": {
+                "bl": "^4.0.1",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
         "test-exclude": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -6693,6 +7602,12 @@
                     }
                 }
             }
+        },
+        "text-hex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+            "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+            "dev": true
         },
         "text-table": {
             "version": "0.2.0",
@@ -6820,6 +7735,12 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
             "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A=="
+        },
+        "triple-beam": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+            "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==",
+            "dev": true
         },
         "ts-mockito": {
             "version": "2.5.0",
@@ -6975,9 +7896,9 @@
             }
         },
         "uglify-js": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.1.tgz",
-            "integrity": "sha512-RjxApKkrPJB6kjJxQS3iZlf///REXWYxYJxO/MpmlQzVkDWVI3PSnCBWezMecmTU/TRkNxrl8bmsfFQCp+LO+Q==",
+            "version": "3.10.3",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.3.tgz",
+            "integrity": "sha512-Lh00i69Uf6G74mvYpHCI9KVVXLcHW/xu79YTvH7Mkc9zyKUeSPz0owW0dguj0Scavns3ZOh3wY63J0Zb97Za2g==",
             "dev": true,
             "optional": true
         },
@@ -7261,6 +8182,106 @@
             "dev": true,
             "requires": {
                 "string-width": "^1.0.2 || 2"
+            }
+        },
+        "widest-line": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+            "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+            "dev": true,
+            "requires": {
+                "string-width": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                }
+            }
+        },
+        "winston": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
+            "integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
+            "dev": true,
+            "requires": {
+                "@dabh/diagnostics": "^2.0.2",
+                "async": "^3.1.0",
+                "is-stream": "^2.0.0",
+                "logform": "^2.2.0",
+                "one-time": "^1.0.0",
+                "readable-stream": "^3.4.0",
+                "stack-trace": "0.0.x",
+                "triple-beam": "^1.3.0",
+                "winston-transport": "^4.4.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "winston-transport": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
+            "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.3.7",
+                "triple-beam": "^1.2.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                }
             }
         },
         "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "pretest": "npm run build",
         "test": "mocha --ui bdd --recursive ./dist/test --timeout 90000",
         "e2econfigcopy": "gulp",
-        "test:e2e": "npm run build && mocha --ui bdd --recursive ./dist/e2e --timeout 90000",
+        "test:e2e": "npm run bootstrap-clean && npm run build && mocha --ui bdd --recursive ./dist/e2e --timeout 90000",
         "test:all": "mocha --ui bdd --recursive ./dist/ --timeout 90000",
         "build": "shx rm -rf dist/ && tsc && npm run e2econfigcopy",
         "test:cov": "nyc --reporter=lcov --reporter=text-summary npm t",
@@ -17,7 +17,13 @@
         "lint": "eslint --cache src/ test/ e2e/ --ext .ts",
         "lint:fix": "eslint src/ test/ e2e/ --ext .ts --fix",
         "style:fix": "npm run prettier && npm run lint:fix",
-        "doc": "typedoc --out \"ts-docs/$(npm run version --silent)\" src"
+        "doc": "typedoc --out \"ts-docs/$(npm run version --silent)\" src",
+        "bootstrap-clean": "symbol-bootstrap clean -t target/bootstrap-test",
+        "bootstrap-start": "symbol-bootstrap start -p bootstrap -c ./e2e/e2e-preset.yml -t target/bootstrap-test -u current",
+        "bootstrap-stop": "symbol-bootstrap stop -t target/bootstrap-test",
+        "bootstrap-run": "symbol-bootstrap run -t target/bootstrap-test",
+        "bootstrap-compose": "symbol-bootstrap compose -t target/bootstrap-test",
+        "bootstrap-config": "symbol-bootstrap config -p bootstrap -c ./e2e/e2e-preset.yml -t target/bootstrap-test"
     },
     "pre-commit": [
         "lint"
@@ -76,6 +82,7 @@
         "prettier": "^2.0.4",
         "secure-random": "^1.1.1",
         "shx": "^0.3.2",
+        "symbol-bootstrap": "0.0.0-alpha-202008261328",
         "ts-mockito": "^2.4.0",
         "ts-node": "^8.6.2",
         "typescript": "^3.7.5",


### PR DESCRIPTION
Added symbol-bootstrap to e2e tests. 

Not all the e2e tests are working, but the infrastructure is now there. Once merged, we need to start fixing the broken e2e tests.

The `e2e` branch is special, like `main` or `release`. It tells Travis to run the e2e tests. These tests can take like an hour to run, so not really practical for PR or main builds atm. In the future, when we want to e2e, we can push main branch into e2e branch. Travis will do the heavy lifting  