### PR TITLE
Consider the size of version in AggregateTransaction.setMaxFeeForAggregate

### DIFF
--- a/src/model/transaction/AggregateTransaction.ts
+++ b/src/model/transaction/AggregateTransaction.ts
@@ -409,8 +409,10 @@ export class AggregateTransaction extends Transaction {
         }
         // Check if current cosignature count is greater than requiredCosignatures.
         const calculatedCosignatures = requiredCosignatures > this.cosignatures.length ? requiredCosignatures : this.cosignatures.length;
+        // version + public key + signature
+        const sizePerCosignature = 8 + 32 + 64;
         // Remove current cosignature length and use the calculated one.
-        const calculatedSize = this.size - this.cosignatures.length * 96 + calculatedCosignatures * 96;
+        const calculatedSize = this.size - this.cosignatures.length * sizePerCosignature + calculatedCosignatures * sizePerCosignature;
         return DtoMapping.assign(this, {
             maxFee: UInt64.fromUint(calculatedSize * feeMultiplier),
         });

--- a/test/model/transaction/AggregateTransaction.spec.ts
+++ b/test/model/transaction/AggregateTransaction.spec.ts
@@ -626,7 +626,9 @@ describe('AggregateTransaction', () => {
             NetworkType.PRIVATE_TEST,
             [],
         ).setMaxFeeForAggregate(2, 10);
-        expect(aggregateTransaction.maxFee.compact()).to.be.equal(560 + 960 * 2);
+        const size = aggregateTransaction.size;
+        expect(size).to.be.equal(280);
+        expect(aggregateTransaction.maxFee.compact()).to.be.equal((size + 104 * 10) * 2);
 
         const signedTransaction = aggregateTransaction.signWith(account, generationHash);
         expect(signedTransaction.hash).not.to.be.undefined;


### PR DESCRIPTION
`AggregateTransaction.setMaxFeeForAggregate` is using `96` as the increased size per co-signature, which is `32 (public key) + 64 (signature)`. The correct size should be `8 (version) + 32 (public key) + 64 (signature) = 104`.

`symbol-sdk-java` is setting the correct number.
https://github.com/nemtech/symbol-sdk-java/blob/2274c70718bbf0ec608ad84df3f2062a5b6c99c3/sdk-core/src/main/java/io/nem/symbol/sdk/model/transaction/AggregateTransactionFactory.java#L34