### PR TITLE
PersistentDelegationRequestTransaction message bug fix

### DIFF
--- a/src/infrastructure/transaction/CreateTransactionFromDTO.ts
+++ b/src/infrastructure/transaction/CreateTransactionFromDTO.ts
@@ -14,50 +14,43 @@
  * limitations under the License.
  */
 import { Convert as convert } from '../../core/format';
-import { UnresolvedMapping } from '../../core/utils/UnresolvedMapping';
-import { Address } from '../../model/account/Address';
-import { PublicAccount } from '../../model/account/PublicAccount';
-import { EncryptedMessage } from '../../model/message/EncryptedMessage';
-import { Message } from '../../model/message/Message';
-import { MessageType } from '../../model/message/MessageType';
-import { PersistentHarvestingDelegationMessage } from '../../model/message/PersistentHarvestingDelegationMessage';
-import { EmptyMessage, PlainMessage } from '../../model/message/PlainMessage';
-import { Mosaic } from '../../model/mosaic/Mosaic';
-import { MosaicFlags } from '../../model/mosaic/MosaicFlags';
-import { MosaicId } from '../../model/mosaic/MosaicId';
-import { MosaicNonce } from '../../model/mosaic/MosaicNonce';
-import { NamespaceId } from '../../model/namespace/NamespaceId';
-import { AccountAddressRestrictionTransaction } from '../../model/transaction/AccountAddressRestrictionTransaction';
-import { AccountKeyLinkTransaction } from '../../model/transaction/AccountKeyLinkTransaction';
-import { AccountMetadataTransaction } from '../../model/transaction/AccountMetadataTransaction';
-import { AccountMosaicRestrictionTransaction } from '../../model/transaction/AccountMosaicRestrictionTransaction';
-import { AccountOperationRestrictionTransaction } from '../../model/transaction/AccountOperationRestrictionTransaction';
-import { AddressAliasTransaction } from '../../model/transaction/AddressAliasTransaction';
-import { AggregateTransaction } from '../../model/transaction/AggregateTransaction';
-import { AggregateTransactionCosignature } from '../../model/transaction/AggregateTransactionCosignature';
-import { AggregateTransactionInfo } from '../../model/transaction/AggregateTransactionInfo';
-import { Deadline } from '../../model/transaction/Deadline';
-import { LockFundsTransaction } from '../../model/transaction/LockFundsTransaction';
-import { MosaicAddressRestrictionTransaction } from '../../model/transaction/MosaicAddressRestrictionTransaction';
-import { MosaicAliasTransaction } from '../../model/transaction/MosaicAliasTransaction';
-import { MosaicDefinitionTransaction } from '../../model/transaction/MosaicDefinitionTransaction';
-import { MosaicGlobalRestrictionTransaction } from '../../model/transaction/MosaicGlobalRestrictionTransaction';
-import { MosaicMetadataTransaction } from '../../model/transaction/MosaicMetadataTransaction';
-import { MosaicSupplyChangeTransaction } from '../../model/transaction/MosaicSupplyChangeTransaction';
-import { MultisigAccountModificationTransaction } from '../../model/transaction/MultisigAccountModificationTransaction';
-import { NamespaceMetadataTransaction } from '../../model/transaction/NamespaceMetadataTransaction';
-import { NamespaceRegistrationTransaction } from '../../model/transaction/NamespaceRegistrationTransaction';
-import { NodeKeyLinkTransaction } from '../../model/transaction/NodeKeyLinkTransaction';
-import { SecretLockTransaction } from '../../model/transaction/SecretLockTransaction';
-import { SecretProofTransaction } from '../../model/transaction/SecretProofTransaction';
-import { SignedTransaction } from '../../model/transaction/SignedTransaction';
-import { Transaction } from '../../model/transaction/Transaction';
-import { TransactionInfo } from '../../model/transaction/TransactionInfo';
-import { TransactionType } from '../../model/transaction/TransactionType';
-import { TransferTransaction } from '../../model/transaction/TransferTransaction';
-import { VotingKeyLinkTransaction } from '../../model/transaction/VotingKeyLinkTransaction';
-import { VrfKeyLinkTransaction } from '../../model/transaction/VrfKeyLinkTransaction';
-import { UInt64 } from '../../model/UInt64';
+import { UnresolvedMapping } from '../../core/utils';
+import { MessageFactory, UInt64 } from '../../model';
+import { Address, PublicAccount } from '../../model/account';
+import { Mosaic, MosaicFlags, MosaicId, MosaicNonce } from '../../model/mosaic';
+import { NamespaceId } from '../../model/namespace';
+import {
+    AccountAddressRestrictionTransaction,
+    AccountKeyLinkTransaction,
+    AccountMetadataTransaction,
+    AccountMosaicRestrictionTransaction,
+    AccountOperationRestrictionTransaction,
+    AddressAliasTransaction,
+    AggregateTransaction,
+    AggregateTransactionCosignature,
+    AggregateTransactionInfo,
+    Deadline,
+    LockFundsTransaction,
+    MosaicAddressRestrictionTransaction,
+    MosaicAliasTransaction,
+    MosaicDefinitionTransaction,
+    MosaicGlobalRestrictionTransaction,
+    MosaicMetadataTransaction,
+    MosaicSupplyChangeTransaction,
+    MultisigAccountModificationTransaction,
+    NamespaceMetadataTransaction,
+    NamespaceRegistrationTransaction,
+    NodeKeyLinkTransaction,
+    SecretLockTransaction,
+    SecretProofTransaction,
+    SignedTransaction,
+    Transaction,
+    TransactionInfo,
+    TransactionType,
+    TransferTransaction,
+    VotingKeyLinkTransaction,
+    VrfKeyLinkTransaction,
+} from '../../model/transaction';
 
 /**
  * Extract recipientAddress value from encoded hexadecimal notation.
@@ -99,29 +92,6 @@ export const extractMosaics = (mosaics: any): Mosaic[] => {
         const id = UnresolvedMapping.toUnresolvedMosaic(mosaicDTO.id);
         return new Mosaic(id, UInt64.fromNumericString(mosaicDTO.amount));
     });
-};
-
-/**
- * Extract message from either JSON payload (unencoded) or DTO (encoded)
- *
- * @param message - message payload
- * @return {Message}
- */
-const extractMessage = (message: any): Message => {
-    let msgObj = EmptyMessage;
-    if (message) {
-        const messagePayload = message.payload ? message.payload : message.substring(2);
-        const messageType = message.type !== undefined ? message.type : convert.hexToUint8(message.substring(0, 2))[0];
-
-        if (messageType === MessageType.PlainMessage) {
-            msgObj = PlainMessage.createFromPayload(messagePayload);
-        } else if (messageType === MessageType.EncryptedMessage) {
-            msgObj = EncryptedMessage.createFromPayload(messagePayload);
-        } else if (messageType === MessageType.PersistentHarvestingDelegationMessage) {
-            msgObj = PersistentHarvestingDelegationMessage.createFromPayload(messagePayload);
-        }
-    }
-    return msgObj;
 };
 
 /**
@@ -168,7 +138,7 @@ const CreateStandaloneTransactionFromDTO = (transactionDTO, transactionInfo): Tr
             UInt64.fromNumericString(transactionDTO.maxFee || '0'),
             extractRecipient(transactionDTO.recipientAddress),
             extractMosaics(transactionDTO.mosaics),
-            extractMessage(transactionDTO.message !== undefined ? transactionDTO.message : undefined),
+            MessageFactory.createMessageFromHex(transactionDTO.message),
             transactionDTO.signature,
             transactionDTO.signerPublicKey
                 ? PublicAccount.createFromPublicKey(transactionDTO.signerPublicKey, transactionDTO.network)

--- a/src/model/message/Message.ts
+++ b/src/model/message/Message.ts
@@ -15,7 +15,7 @@ import { Convert } from '../../core/format/Convert';
  * limitations under the License.
  */
 
-import { Convert } from '../../core/format/Convert';
+import { Convert } from '../../core/format';
 import { MessageType } from './MessageType';
 
 /**
@@ -40,9 +40,9 @@ export abstract class Message {
         /**
          * Message type
          */
-        public readonly type: number,
+        public readonly type: MessageType,
         /**
-         * Message payload
+         * Message payload, it could be the message hex, encryped text or plain text depending on the message type.
          */
         public readonly payload: string,
     ) {}
@@ -54,8 +54,12 @@ export abstract class Message {
         if (!this.payload) {
             return '';
         }
-        return this.type === MessageType.PersistentHarvestingDelegationMessage
-            ? this.payload
-            : this.type.toString(16).padStart(2, '0').toUpperCase() + Convert.utf8ToHex(this.payload);
+        if (this.type === MessageType.PersistentHarvestingDelegationMessage) {
+            return this.payload;
+        }
+        if (this.type === MessageType.RawMessage) {
+            return this.payload;
+        }
+        return this.type.toString(16).padStart(2, '0').toUpperCase() + Convert.utf8ToHex(this.payload);
     }
 }

--- a/src/model/message/MessageFactory.ts
+++ b/src/model/message/MessageFactory.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Convert } from '../../core/format';
+import { EncryptedMessage } from './EncryptedMessage';
+import { Message } from './Message';
+import { MessageMarker } from './MessageMarker';
+import { MessageType } from './MessageType';
+import { PersistentHarvestingDelegationMessage } from './PersistentHarvestingDelegationMessage';
+import { PlainMessage } from './PlainMessage';
+import { RawMessage } from './RawMessage';
+
+/**
+ * Objects that knows how to create messages from serialized payloads.
+ *
+ * Note: this could be in the Message class but the circular dependency breaks Typescript.
+ */
+export class MessageFactory {
+    /**
+     * It creates a message from the byte array payload
+     * @param payload the payload as byte array
+     */
+    public static createMessageFromBuffer(payload?: Uint8Array): Message {
+        return this.createMessageFromHex(payload ? Convert.uint8ToHex(payload) : undefined);
+    }
+    /**
+     * It creates a message from the hex payload
+     * @param payload the payload as byte array
+     */
+    public static createMessageFromHex(payload?: string): Message {
+        if (!payload || !payload.length) {
+            return new RawMessage('');
+        }
+        if (payload.length == 264 && payload.startsWith(MessageMarker.PersistentDelegationUnlock)) {
+            return new PersistentHarvestingDelegationMessage(payload);
+        }
+        const messageType = Convert.hexToUint8(payload)[0];
+        switch (messageType) {
+            case MessageType.PlainMessage:
+                return new PlainMessage(Message.decodeHex(payload.substring(2)));
+            case MessageType.EncryptedMessage:
+                return new EncryptedMessage(Message.decodeHex(payload.substring(2)));
+        }
+        return new RawMessage(payload);
+    }
+}
+
+/**
+ * Raw message containing an empty string without any type or prefix.
+ * @type {PlainMessage}
+ */
+export const EmptyMessage: Message = MessageFactory.createMessageFromBuffer();

--- a/src/model/message/MessageType.ts
+++ b/src/model/message/MessageType.ts
@@ -16,11 +16,13 @@
 
 /**
  * The Message type. Supported supply types are:
+ * -1: RawMessage (no type appended)
  * 0: PlainMessage
  * 1: EncryptedMessage.
  * 254: Persistent harvesting delegation.
  */
 export enum MessageType {
+    RawMessage = -1,
     PlainMessage = 0x00,
     EncryptedMessage = 0x01,
     PersistentHarvestingDelegationMessage = 0xfe,

--- a/src/model/message/PersistentHarvestingDelegationMessage.ts
+++ b/src/model/message/PersistentHarvestingDelegationMessage.ts
@@ -15,9 +15,9 @@
  */
 
 import { Crypto } from '../../core/crypto';
-import { Convert } from '../../core/format/Convert';
-import { Account } from '../account/Account';
-import { NetworkType } from '../network/NetworkType';
+import { Convert } from '../../core/format';
+import { Account } from '../account';
+import { NetworkType } from '../network';
 import { Message } from './Message';
 import { MessageMarker } from './MessageMarker';
 import { MessageType } from './MessageType';

--- a/src/model/message/RawMessage.ts
+++ b/src/model/message/RawMessage.ts
@@ -14,33 +14,26 @@
  * limitations under the License.
  */
 
+import { Convert } from '../../core/format';
 import { Message } from './Message';
 import { MessageType } from './MessageType';
 
 /**
- * The plain message model defines a plain string. When sending it to the network we transform the payload to hex-string.
+ * The a raw message that doesn't assume any prefix.
  */
-export class PlainMessage extends Message {
+export class RawMessage extends Message {
     /**
      * Create plain message object.
      * @returns PlainMessage
      */
-    public static create(message: string): PlainMessage {
-        return new PlainMessage(message);
+    public static create(payload: Uint8Array): RawMessage {
+        return new RawMessage(Convert.uint8ToHex(payload));
     }
-
-    /**
-     * @internal
-     */
-    public static createFromPayload(payload: string): PlainMessage {
-        return new PlainMessage(this.decodeHex(payload));
-    }
-
     /**
      * @internal
      * @param payload
      */
     constructor(payload: string) {
-        super(MessageType.PlainMessage, payload);
+        super(MessageType.RawMessage, payload);
     }
 }

--- a/src/model/message/index.ts
+++ b/src/model/message/index.ts
@@ -2,7 +2,9 @@
 
 export * from './EncryptedMessage';
 export * from './Message';
+export * from './MessageFactory';
 export * from './MessageMarker';
 export * from './MessageType';
 export * from './PersistentHarvestingDelegationMessage';
 export * from './PlainMessage';
+export * from './RawMessage';

--- a/src/model/transaction/TransferTransaction.ts
+++ b/src/model/transaction/TransferTransaction.ts
@@ -30,20 +30,13 @@ import {
 } from 'catbuffer-typescript';
 import * as Long from 'long';
 import { Convert } from '../../core/format';
-import { DtoMapping } from '../../core/utils/DtoMapping';
-import { UnresolvedMapping } from '../../core/utils/UnresolvedMapping';
-import { Address } from '../account/Address';
-import { PublicAccount } from '../account/PublicAccount';
-import { UnresolvedAddress } from '../account/UnresolvedAddress';
-import { EncryptedMessage } from '../message/EncryptedMessage';
-import { Message } from '../message/Message';
-import { MessageType } from '../message/MessageType';
-import { PersistentHarvestingDelegationMessage } from '../message/PersistentHarvestingDelegationMessage';
-import { EmptyMessage, PlainMessage } from '../message/PlainMessage';
-import { Mosaic } from '../mosaic/Mosaic';
-import { NamespaceId } from '../namespace/NamespaceId';
-import { NetworkType } from '../network/NetworkType';
-import { Statement } from '../receipt/Statement';
+import { DtoMapping, UnresolvedMapping } from '../../core/utils';
+import { Address, PublicAccount, UnresolvedAddress } from '../account';
+import { EmptyMessage, Message, MessageFactory, MessageType } from '../message';
+import { Mosaic } from '../mosaic';
+import { NamespaceId } from '../namespace';
+import { NetworkType } from '../network';
+import { Statement } from '../receipt';
 import { UInt64 } from '../UInt64';
 import { Deadline } from './Deadline';
 import { InnerTransaction } from './InnerTransaction';
@@ -151,7 +144,7 @@ export class TransferTransaction extends Transaction {
                 const id = new UInt64(mosaic.mosaicId.unresolvedMosaicId).toHex();
                 return new Mosaic(UnresolvedMapping.toUnresolvedMosaic(id), new UInt64(mosaic.amount.amount));
             }),
-            TransferTransaction.createMessageFromBuffer(builder.getMessage()),
+            MessageFactory.createMessageFromBuffer(builder.getMessage()),
             networkType,
             isEmbedded ? new UInt64([0, 0]) : new UInt64((builder as TransferTransactionBuilder).fee.amount),
             isEmbedded || signature.match(`^[0]+$`) ? undefined : signature,
@@ -297,26 +290,5 @@ export class TransferTransaction extends Transaction {
             this.recipientAddress.equals(address) ||
             alias.find((name) => this.recipientAddress.equals(name)) !== undefined
         );
-    }
-
-    /**
-     * @internal
-     */
-    private static createMessageFromBuffer(messageBuffer: Uint8Array): Message {
-        if (!messageBuffer.length) {
-            return EmptyMessage;
-        }
-        const messageType = messageBuffer[0];
-        const messageHex = Convert.uint8ToHex(messageBuffer).substring(2);
-        switch (messageType) {
-            case MessageType.PlainMessage:
-                return PlainMessage.createFromPayload(messageHex);
-            case MessageType.EncryptedMessage:
-                return EncryptedMessage.createFromPayload(messageHex);
-            case MessageType.PersistentHarvestingDelegationMessage:
-                return PersistentHarvestingDelegationMessage.createFromPayload(messageHex);
-            default:
-                throw new Error('Message Type is not valid');
-        }
     }
 }

--- a/test/core/utils/TransactionMapping.spec.ts
+++ b/test/core/utils/TransactionMapping.spec.ts
@@ -22,6 +22,7 @@ import { Convert } from '../../../src/core/format';
 import { TransactionMapping } from '../../../src/core/utils/TransactionMapping';
 import { Account, Address } from '../../../src/model/account';
 import { LockHashAlgorithm } from '../../../src/model/lock/LockHashAlgorithm';
+import { MessageMarker } from '../../../src/model/message';
 import { EncryptedMessage } from '../../../src/model/message/EncryptedMessage';
 import { MessageType } from '../../../src/model/message/MessageType';
 import { PlainMessage } from '../../../src/model/message/PlainMessage';
@@ -1365,5 +1366,17 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
         expect(transaction.valueSizeDelta).to.be.equal(1);
         expect(transaction.targetNamespaceId.toHex()).to.be.equal(new NamespaceId([2262289484, 3405110546]).toHex());
         expect(transaction.value).to.be.equal('Test Value');
+    });
+
+    it('should create from payload with persistent delegate message', () => {
+        const transferTransaction = TransactionMapping.createFromPayload(
+            '2401000000000000B69B5CB2CE79B5E06117D246E84CB21095BAC0E78A4F01E2D4E3F068EF2E3370B907495FE6BC9A130D05A8BDB49E8AD398FBA40569C921907297AB0D5778C00D2D13E2FDC654936417899AB63D709B9A7A603BA1D20557AA06CE5B2C9242F035000000000198544140420F00000000009A19B31107000000981E13520236DBBD06F8C08710289BD9CF598A01C29E04668400000000000000E201735761802AFECBD67E2DBA5D69157CE32874EFDD680E41B1BFFD12B781F84E8AD883920BBB50EA38AFE078E99EE5EE4BDFDA77E8C101EBD3100C0D471673471A61B23E513FC7E21F7803316B906A688F14AA75002913A3B57DD13469BC27CF8C82FD5C4C76867011AEDC7C4870D8C5AF9C175F0DA5A8E2AD3A327D868BFBA34A5E3D',
+        ) as TransferTransaction;
+
+        expect(transferTransaction.message.type).eq(MessageType.PersistentHarvestingDelegationMessage);
+        expect(transferTransaction.message.payload).eq(
+            MessageMarker.PersistentDelegationUnlock +
+                'CBD67E2DBA5D69157CE32874EFDD680E41B1BFFD12B781F84E8AD883920BBB50EA38AFE078E99EE5EE4BDFDA77E8C101EBD3100C0D471673471A61B23E513FC7E21F7803316B906A688F14AA75002913A3B57DD13469BC27CF8C82FD5C4C76867011AEDC7C4870D8C5AF9C175F0DA5A8E2AD3A327D868BFBA34A5E3D',
+        );
     });
 });

--- a/test/infrastructure/transaction/CreateTransactionFromDTO.spec.ts
+++ b/test/infrastructure/transaction/CreateTransactionFromDTO.spec.ts
@@ -16,15 +16,35 @@
 import { LocalDateTime } from '@js-joda/core';
 import { deepEqual } from 'assert';
 import { expect } from 'chai';
-import { CreateTransactionFromDTO } from '../../../src/infrastructure/transaction/CreateTransactionFromDTO';
-import { Address } from '../../../src/model/account/Address';
-import { TransferTransaction } from '../../../src/model/transaction/TransferTransaction';
+import { NamespaceRegistrationTypeEnum, TransactionInfoDTO, TransferTransactionDTO } from 'symbol-openapi-typescript-fetch-client';
+import { CreateTransactionFromDTO } from '../../../src/infrastructure/transaction';
+import { Address } from '../../../src/model/account';
+import { TransferTransaction } from '../../../src/model/transaction';
 import ValidateTransaction from './ValidateTransaction';
 
 describe('CreateTransactionFromDTO', () => {
     describe('TransferTransaction', () => {
         it('standalone', () => {
-            const transferTransactionDTO = {
+            const transactionDto = {
+                size: 100,
+                signature:
+                    '7442156D839A3AC900BC0299E8701ECDABA674DCF91283223450953B005DE72C538EA54236F5E089530074CE78067CD3325CF53750B9118154C08B20A5CDC00D',
+                signerPublicKey: '2FC3872A792933617D70E02AFF8FBDE152821A0DF0CA5FB04CB56FC3D21C8863',
+                version: 1,
+                network: 144,
+                type: 16724,
+                maxFee: '0',
+                deadline: '1000',
+                recipientAddress: '7826D27E1D0A26CA4E316F901E23E55C8711DB20DF5C49B5',
+                message: '00746573742D6D657373616765',
+                mosaics: [
+                    {
+                        id: '85BBEA6CC462B244',
+                        amount: '10',
+                    },
+                ],
+            } as TransferTransactionDTO;
+            const transferTransactionDTO: TransactionInfoDTO = {
                 id: '5CD2B76B2B3F0F0001751380',
                 meta: {
                     height: '78',
@@ -32,38 +52,18 @@ describe('CreateTransactionFromDTO', () => {
                     merkleComponentHash: '533243B8575C4058F894C453160AFF055A4A905978AC331460F44104D831E4AC',
                     index: 0,
                 },
-                transaction: {
-                    size: 100,
-                    signature:
-                        '7442156D839A3AC900BC0299E8701ECDABA674DCF91283223450953B005DE72C538EA54236F5E089530074CE78067CD3325CF53750B9118154C08B20A5CDC00D',
-                    signerPublicKey: '2FC3872A792933617D70E02AFF8FBDE152821A0DF0CA5FB04CB56FC3D21C8863',
-                    version: 1,
-                    network: 144,
-                    type: 16724,
-                    maxFee: '0',
-                    deadline: '1000',
-                    recipientAddress: '7826D27E1D0A26CA4E316F901E23E55C8711DB20DF5C49B5',
-                    message: {
-                        payload: '746573742D6D657373616765',
-                        type: 0,
-                    },
-                    mosaics: [
-                        {
-                            id: '85BBEA6CC462B244',
-                            amount: '10',
-                        },
-                    ],
-                },
+                transaction: transactionDto,
             };
 
             const transferTransaction = CreateTransactionFromDTO(transferTransactionDTO) as TransferTransaction;
-            deepEqual(transferTransaction.recipientAddress, Address.createFromEncoded(transferTransactionDTO.transaction.recipientAddress));
+            deepEqual(transferTransaction.recipientAddress, Address.createFromEncoded(transactionDto.recipientAddress));
             expect(transferTransaction.message.payload).to.be.equal('test-message');
             expect(transferTransaction.size).to.be.equal(100);
         });
 
         it('standalone without message', () => {
-            const transferTransactionDTO = {
+            const recipientAddress = '7826D27E1D0A26CA4E316F901E23E55C8711DB20DF5C49B5';
+            const transferTransactionDTO: TransactionInfoDTO = {
                 id: '5CD2B76B2B3F0F0001751380',
                 meta: {
                     height: '78',
@@ -81,7 +81,7 @@ describe('CreateTransactionFromDTO', () => {
                     type: 16724,
                     maxFee: '0',
                     deadline: '1000',
-                    recipientAddress: '7826D27E1D0A26CA4E316F901E23E55C8711DB20DF5C49B5',
+                    recipientAddress: recipientAddress,
                     mosaics: [
                         {
                             id: '85BBEA6CC462B244',
@@ -92,7 +92,7 @@ describe('CreateTransactionFromDTO', () => {
             };
 
             const transferTransaction = CreateTransactionFromDTO(transferTransactionDTO) as TransferTransaction;
-            deepEqual(transferTransaction.recipientAddress, Address.createFromEncoded(transferTransactionDTO.transaction.recipientAddress));
+            deepEqual(transferTransaction.recipientAddress, Address.createFromEncoded(recipientAddress));
             expect(transferTransaction.message.payload).to.be.equal('');
             expect(transferTransaction.size).to.be.equal(100);
         });
@@ -133,10 +133,7 @@ describe('CreateTransactionFromDTO', () => {
                                 index: 0,
                             },
                             transaction: {
-                                message: {
-                                    payload: '746573742D6D657373616765',
-                                    type: 0,
-                                },
+                                message: '00746573742D6D657373616765',
                                 mosaics: [
                                     {
                                         amount: '1000',
@@ -179,10 +176,7 @@ describe('CreateTransactionFromDTO', () => {
                     network: 144,
                     type: 16724,
                     recipientAddress: '7826D27E1D0A26CA4E316F901E23E55C8711DB20DF5C49B5',
-                    message: {
-                        payload: '746573742D6D657373616765',
-                        type: 0,
-                    },
+                    message: '00746573742D6D657373616765',
                     mosaics: [
                         {
                             id: '85BBEA6CC462B244',
@@ -218,7 +212,7 @@ describe('CreateTransactionFromDTO', () => {
                         maxFee: '0',
                         name: 'a2p1mg',
                         id: '85BBEA6CC462B244',
-                        registrationType: 0,
+                        registrationType: NamespaceRegistrationTypeEnum.NUMBER_0,
                         signature:
                             '553E696EB4A54E43A11D180EBA57E4B89D0048C9DD2604A9E0608120018B9E0' +
                             '2F6EE63025FEEBCED3293B622AF8581334D0BDAB7541A9E7411E7EE4EF0BC5D0E',

--- a/test/model/message/PlainMessage.spec.ts
+++ b/test/model/message/PlainMessage.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { expect } from 'chai';
-import { EmptyMessage, PlainMessage } from '../../../src/model/message/PlainMessage';
+import { EmptyMessage, PlainMessage } from '../../../src/model/message';
 
 describe('PlainMessage', () => {
     it('should createComplete an empty message', () => {

--- a/test/model/transaction/CosignatureTransaction.spec.ts
+++ b/test/model/transaction/CosignatureTransaction.spec.ts
@@ -67,10 +67,7 @@ describe('CosignatureTransaction', () => {
                         index: 0,
                     },
                     transaction: {
-                        message: {
-                            payload: '746573742D6D657373616765',
-                            type: 0,
-                        },
+                        message: '00746573742D6D657373616765',
                         mosaics: [
                             {
                                 amount: '100',

--- a/test/model/transaction/TransferTransaction.spec.ts
+++ b/test/model/transaction/TransferTransaction.spec.ts
@@ -15,28 +15,18 @@
  */
 
 import { expect } from 'chai';
+import { TransactionInfoDTO } from 'symbol-openapi-typescript-fetch-client';
 import { Convert } from '../../../src/core/format';
-import { CreateTransactionFromPayload } from '../../../src/infrastructure/transaction/CreateTransactionFromPayload';
-import { Account } from '../../../src/model/account/Account';
-import { Address } from '../../../src/model/account/Address';
-import { MessageMarker } from '../../../src/model/message/MessageMarker';
-import { MessageType } from '../../../src/model/message/MessageType';
-import { PersistentHarvestingDelegationMessage } from '../../../src/model/message/PersistentHarvestingDelegationMessage';
-import { EmptyMessage, PlainMessage } from '../../../src/model/message/PlainMessage';
-import { Mosaic } from '../../../src/model/mosaic/Mosaic';
-import { MosaicId } from '../../../src/model/mosaic/MosaicId';
-import { NamespaceId } from '../../../src/model/namespace/NamespaceId';
-import { NetworkType } from '../../../src/model/network/NetworkType';
-import { ReceiptSource } from '../../../src/model/receipt/ReceiptSource';
-import { ResolutionEntry } from '../../../src/model/receipt/ResolutionEntry';
-import { ResolutionStatement } from '../../../src/model/receipt/ResolutionStatement';
-import { ResolutionType } from '../../../src/model/receipt/ResolutionType';
-import { Statement } from '../../../src/model/receipt/Statement';
-import { AggregateTransaction } from '../../../src/model/transaction/AggregateTransaction';
-import { Deadline } from '../../../src/model/transaction/Deadline';
-import { TransactionInfo } from '../../../src/model/transaction/TransactionInfo';
-import { TransferTransaction } from '../../../src/model/transaction/TransferTransaction';
-import { UInt64 } from '../../../src/model/UInt64';
+import { TransactionMapping } from '../../../src/core/utils';
+import { CreateTransactionFromPayload } from '../../../src/infrastructure/transaction';
+import { PersistentHarvestingDelegationMessage, UInt64 } from '../../../src/model';
+import { Account, Address } from '../../../src/model/account';
+import { EmptyMessage, MessageMarker, MessageType, PlainMessage } from '../../../src/model/message';
+import { Mosaic, MosaicId } from '../../../src/model/mosaic';
+import { NamespaceId } from '../../../src/model/namespace';
+import { NetworkType } from '../../../src/model/network';
+import { ReceiptSource, ResolutionEntry, ResolutionStatement, ResolutionType, Statement } from '../../../src/model/receipt';
+import { AggregateTransaction, Deadline, TransactionInfo, TransferTransaction } from '../../../src/model/transaction';
 import { TestingAccount } from '../../conf/conf.spec';
 import { NetworkCurrencyLocal } from '../mosaic/Currency.spec';
 
@@ -329,6 +319,39 @@ describe('TransferTransaction', () => {
                 NetworkType.PRIVATE_TEST,
             );
         }).to.throw();
+    });
+    it('should load message with persistent message delegate', () => {
+        const messageHex =
+            'E201735761802AFE9FB4BD2BA099AFA82DDB0212080CF649F0CB0FADAD7BA4CC04BE51E40A4EF0A27B8E2BEAB595F4075BB5A6A481835F3A6E4BBA63091A5866D90D2B7ACBBF158E51FE074619C4B0FF0C4AFEE1AE9A4D83A5A7A156C91CCA3A319D3279A64A63491E19656F7211760BB36EF6B3263C03837CE00E84FD82B32B721120DE';
+        const payload: TransactionInfoDTO = {
+            meta: {
+                height: '108907',
+                hash: '9661088F22C2DC72E76EE2B0F07BFC0D8E98EEE0CC8AE274362EDBB44F164F16',
+                merkleComponentHash: '9661088F22C2DC72E76EE2B0F07BFC0D8E98EEE0CC8AE274362EDBB44F164F16',
+                index: 0,
+            },
+            transaction: {
+                size: 292,
+                signature:
+                    '494A6AF4CDA3C8B5ED0061F561F65EFCBF911BC5179B120440A753345B209F380CE3417D40B773D755746C5B5DACC2F0C78B6A0EAC093CE96CBA18E45380B50C',
+                signerPublicKey: '60FAE3A39D580BB5118686569D159E3F2B991504D3ED0A304C3B7DA5FCCD0353',
+                version: 1,
+                network: 152,
+                type: 16724,
+                maxFee: '20000000',
+                deadline: '30905923815',
+                recipientAddress: '98BE002792600453CF3A23F9894BDA172CE4EFA7C6F3C109',
+                message: messageHex,
+                mosaics: [],
+            },
+            id: '5FA01EB485AC1F1E51EAA6BF',
+        };
+
+        const transaction = TransactionMapping.createFromDTO(payload);
+        const transferTransaction = transaction as TransferTransaction;
+        expect(transferTransaction.message.payload).eq(messageHex);
+        expect(transferTransaction.message.type).eq(MessageType.PersistentHarvestingDelegationMessage);
+        console.log(transferTransaction.message.payload);
     });
 
     it('should throw exception with invalid private key when creating persistentDelegationRequestTransaction', () => {


### PR DESCRIPTION
Fixes https://github.com/nemtech/symbol-sdk-typescript-javascript/issues/704.

Also, the new EmtpyMessage is a real Empty message without the 00 prefix (like java and server when creating transfer transactions)

The Message.payload is confusing, sometimes is an hex, sometime is plain text, sometime is a encrypted text. I would like to improve this but probably in a later PR.