### PR TITLE
fix import path

### DIFF
--- a/src/core/utils/DtoMapping.ts
+++ b/src/core/utils/DtoMapping.ts
@@ -15,8 +15,12 @@
  */
 
 import { Duration } from '@js-joda/core';
-import { AccountRestrictionsInfoDTO, MerkleTreeBranchDTO, MerkleTreeLeafDTO } from 'symbol-openapi-typescript-fetch-client';
-import { MerkleStateInfoDTO } from 'symbol-openapi-typescript-fetch-client/src/models/index';
+import {
+    AccountRestrictionsInfoDTO,
+    MerkleStateInfoDTO,
+    MerkleTreeBranchDTO,
+    MerkleTreeLeafDTO,
+} from 'symbol-openapi-typescript-fetch-client';
 import { Address } from '../../model/account/Address';
 import { MerkleStateInfo } from '../../model/blockchain/MerkleStateInfo';
 import { MosaicId } from '../../model/mosaic/MosaicId';


### PR DESCRIPTION
`MerkleStateInfoDTO` is exported directly from `symbol-openapi-typescript-fetch-client`.

Also, the compiled `d.ts` contains `import { MerkleStateInfoDTO } from 'symbol-openapi-typescript-fetch-client/src/models/index'`, so it refers to the code before compilation.